### PR TITLE
feat(header): 로고/버튼/햄버거 아이콘 포함 헤더 레이아웃 구현

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import Footer from "@/components/footer/Footer";
+import Header from "@/components/header/Header";
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -23,7 +24,8 @@ export default function RootLayout({
         />
       </head>
       <body className="min-h-screen flex flex-col">
-        <div className="mx-auto md:container md:min-h-[calc(100dvh-358px-64px)]">
+        <div className="flex flex-col mx-auto md:container md:min-h-[calc(100dvh-358px-64px)]">
+          <Header />
           <main className="flex-1">{children}</main>
         </div>
         <Footer />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,3 @@
 export default function Home() {
-  return (
-    <div className="">
-      <div className="">Hello World</div>
-    </div>
-  );
+  return <></>;
 }

--- a/src/components/footer/FooterCompanyLogos.tsx
+++ b/src/components/footer/FooterCompanyLogos.tsx
@@ -13,13 +13,55 @@ import {
 const FooterCompanyLogos = () => {
   return (
     <div className="grid grid-cols-3 flex-wrap items-center md:grid-cols-4 lg:flex mt-3 md:mt-7">
-      <Image src={KB금융그룹} alt="KB금융그룹" />
-      <Image src={KB국민카드} alt="KB국민카드" />
-      <Image src={키움캐피탈} alt="키움캐피탈" />
-      <Image src={금융위원회} alt="금융위원회" />
-      <Image src={아기유니콘} alt="아기유니콘" />
-      <Image src={벤처확인기업} alt="벤처확인기업" />
-      <Image src={기술보증} alt="기술보증" />
+      <Image
+        loading="lazy"
+        width={106}
+        height={48}
+        src={KB금융그룹}
+        alt="KB금융그룹"
+      />
+      <Image
+        loading="lazy"
+        width={106}
+        height={48}
+        src={KB국민카드}
+        alt="KB국민카드"
+      />
+      <Image
+        loading="lazy"
+        width={106}
+        height={48}
+        src={키움캐피탈}
+        alt="키움캐피탈"
+      />
+      <Image
+        loading="lazy"
+        width={106}
+        height={48}
+        src={금융위원회}
+        alt="금융위원회"
+      />
+      <Image
+        loading="lazy"
+        width={106}
+        height={48}
+        src={아기유니콘}
+        alt="아기유니콘"
+      />
+      <Image
+        loading="lazy"
+        width={106}
+        height={48}
+        src={벤처확인기업}
+        alt="벤처확인기업"
+      />
+      <Image
+        loading="lazy"
+        width={106}
+        height={48}
+        src={기술보증}
+        alt="기술보증"
+      />
     </div>
   );
 };

--- a/src/components/footer/FooterLogo.tsx
+++ b/src/components/footer/FooterLogo.tsx
@@ -15,29 +15,12 @@ const FooterLogo = () => {
       />
       <div className="mt-6 flex flex-col gap-6 md:mt-9">
         <main>
-          <ul className="flex flex-wrap items-center text-body-3 text-label-700 [&_a:hover]:font-bold [&>li:not(:first-child)]:before:content-['·'] [&>li:not(:first-child)]:before:mx-2">
-            <li>
-              <a href="/">Home</a>
-            </li>
-            <li>
-              <a href="/">사용자 이용약관</a>
-            </li>
-            <li>
-              <a href="/">개인정보 처리방침</a>
-            </li>
-            <li>
-              <a href="/">공지사항</a>
-            </li>
-            <li>
-              <a href="/">FAQ</a>
-            </li>
-            <li>
-              <a href="/">블로그</a>
-            </li>
-            <li>
-              <a href="/">채용정보</a>
-            </li>
-          </ul>
+          <div className="flex flex-wrap items-center gap-2 text-body-3 text-label-700 [&_a:hover]:font-bold">
+            <a href="/">Home</a> ·<a href="/">사용자 이용약관</a> ·{" "}
+            <a href="/">개인정보 처리방침</a> · <a href="/">공지사항</a> ·{" "}
+            <a href="/">FAQ</a>· <a href="/">블로그</a> ·{" "}
+            <a href="/">채용정보</a>
+          </div>
         </main>
         <main>
           <div className="text-body-3 font-normal text-label-500 lg:text-body-2">

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -1,23 +1,25 @@
 import React from "react";
-import { LogoGradient } from "@/shared/icons/logo";
-import Image from "next/image";
+import HeaderLogo from "./HeaderLogo";
+import HeaderMobileActions from "./HeaderMobileActions";
+import HeaderDesktopActions from "./HeaderDesktopActions";
+
 const Header = () => {
   return (
     <header>
-      <div className="fixed top-0 left-0 z-40 h-header w-full bg-background-default">
+      <div className="fixed top-0 left-0 z-40 h-[60px] w-full bg-background-default">
         <div className="size-full">
           <div className="container flex h-full items-center justify-between *:h-full">
-            <div className="flex items-center gap-11">
-              <a aria-label="초간편 통합 선정산서비스 올라" href="/">
-                <Image src={LogoGradient} alt="allra logo" />
-              </a>
-            </div>
-            <div></div>
-            <div></div>
+            <HeaderLogo />
+            <HeaderMobileActions />
+            <HeaderDesktopActions />
           </div>
+          <div
+            data-orientation="horizontal"
+            role="none"
+            className="shrink-0 !h-px w-full bg-line-200"
+          ></div>
         </div>
       </div>
-      <div></div>
     </header>
   );
 };

--- a/src/components/header/HeaderDesktopActions.tsx
+++ b/src/components/header/HeaderDesktopActions.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import Link from "next/link";
+
+const HeaderDesktopActions = () => {
+  return (
+    <div className="flex items-center gap-4 max-lg:hidden">
+      <Link
+        href="/"
+        className="inline-flex items-center justify-center whitespace-nowrap cursor-pointer disabled:cursor-not-allowed border border-secondary-300 bg-background-default text-primary hover:border-secondary-300 hover:bg-label-100 active:bg-background-alternative disabled:border-status-disable disabled:bg-background-default disabled:text-status-disable h-[32px] gap-1 rounded-sm px-6 text-body-3 font-medium"
+      >
+        회원가입
+      </Link>
+      <Link
+        href="/"
+        className="inline-flex items-center justify-center whitespace-nowrap cursor-pointer disabled:cursor-not-allowed border bg-background-default text-label-800 hover:bg-label-100 active:bg-background-alternative disabled:border-line-400 disabled:text-status-disable h-[32px] gap-1 rounded-sm px-6 text-body-3 font-medium"
+      >
+        로그인
+      </Link>
+    </div>
+  );
+};
+
+export default HeaderDesktopActions;

--- a/src/components/header/HeaderLogo.tsx
+++ b/src/components/header/HeaderLogo.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { LogoGradient } from "@/shared/icons/logo";
+import Image from "next/image";
+
+const HeaderLogo = () => {
+  return (
+    <div className="flex items-center gap-11">
+      <a aria-label="초간편 통합 선정산서비스 올라" href="/">
+        <Image
+          src={LogoGradient}
+          alt="allra logo"
+          loading="lazy"
+          width={92}
+          height={24}
+          decoding="async"
+        />
+      </a>
+    </div>
+  );
+};
+
+export default HeaderLogo;

--- a/src/components/header/HeaderMobileActions.tsx
+++ b/src/components/header/HeaderMobileActions.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import Link from "next/link";
+import { HamburgerIcon } from "@/shared/icons/etc";
+
+const HeaderMobileActions = () => {
+  return (
+    <div className="flex items-center gap-4 lg:hidden">
+      <Link
+        href="/"
+        className="inline-flex items-center justify-center whitespace-nowrap cursor-pointer disabled:cursor-not-allowed border border-secondary-300 bg-background-default text-primary hover:border-secondary-300 hover:bg-label-100 active:bg-background-alternative disabled:border-status-disable disabled:bg-background-default disabled:text-status-disable h-[32px] gap-1 rounded-sm px-6 text-body-3 font-medium"
+      >
+        로그인/회원가입
+      </Link>
+      <HamburgerIcon className="w-[24px] h-[24px]" />
+    </div>
+  );
+};
+
+export default HeaderMobileActions;

--- a/src/shared/icons/etc/HamburgerIcon.tsx
+++ b/src/shared/icons/etc/HamburgerIcon.tsx
@@ -1,0 +1,18 @@
+export function HamburgerIcon({ className = "w-6 h-6" }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M4 6h16M4 12h16M4 18h16"
+      />
+    </svg>
+  );
+}

--- a/src/shared/icons/etc/index.ts
+++ b/src/shared/icons/etc/index.ts
@@ -1,0 +1,1 @@
+export { HamburgerIcon } from "./HamburgerIcon";

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,6 +21,26 @@ module.exports = {
       },
     },
     extend: {
+      spacing: {
+        0: "0",
+        1: "0.125rem", // 2px
+        2: "0.25rem", // 4px
+        3: "0.375rem", // 6px
+        4: "0.5rem", // 8px
+        5: "0.625rem", // 10px
+        6: "1rem", // 16px
+        7: "1.25rem", // 20px
+        8: "1.5rem", // 24px
+        9: "2rem", // 32px
+        10: "2.5rem", // 40px
+        11: "3rem", // 48px
+        12: "3.5rem", // 56px
+        13: "4rem", // 64px
+        14: "5rem", // 80px
+        header: "60px",
+        "breadcrumb-tablet": "40px",
+        "breadcrumb-mobile": "33px",
+      },
       fontFamily: {
         pretendard: ["Pretendard", "sans-serif"],
       },


### PR DESCRIPTION
## 변경 사항
- Header 컴포넌트 도입
  - `src/components/header/Header.tsx` 고정 상단바(높이 60px) 및 구분선 추가
  - `HeaderLogo`, `HeaderMobileActions`, `HeaderDesktopActions` 분리 구성
- 레이아웃 반영
  - `src/app/layout.tsx`에 `Header` 삽입, 컨테이너를 `flex-col`로 정리
- 아이콘
  - `HamburgerIcon` 추가 및 `shared/icons/etc/index.ts`에서 export
- 홈 페이지
  - `src/app/page.tsx` 임시 콘텐츠 제거
- Footer 보완
  - `FooterCompanyLogos` 이미지에 `loading="lazy"` 및 고정 크기(106x48) 지정
  - `FooterLogo` 링크 목록 마크업 단순화(인라인 · 구분)
- Tailwind 설정
  - `tailwind.config.js` spacing 확장: `header: 60px`, breadcrumb 값 추가