### PR TITLE
feat(api): api 설정 완료

### DIFF
--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,0 +1,75 @@
+import fetcher from "@/apis/fetcher";
+import { ENDPOINT } from "@/apis/url";
+import type {
+  LoginArgs,
+  LoginResponse,
+  MeResponse,
+  RegisterArgs,
+  RegisterResponse,
+  VerifyBusinessNumberArgs,
+  VerifyBusinessNumberResponse,
+  RefreshTokenResponse,
+} from "@/types/auth";
+
+const ACCESS_TOKEN_KEY = "accessToken";
+const REFRESH_TOKEN_KEY = "refreshToken";
+
+export const saveTokens = (
+  partial: Partial<LoginResponse | RefreshTokenResponse>
+) => {
+  if (partial.accessToken)
+    localStorage.setItem(ACCESS_TOKEN_KEY, partial.accessToken);
+  if (partial.refreshToken)
+    localStorage.setItem(REFRESH_TOKEN_KEY, partial.refreshToken);
+};
+export const getAccessToken = () => localStorage.getItem(ACCESS_TOKEN_KEY);
+export const getRefreshToken = () => localStorage.getItem(REFRESH_TOKEN_KEY);
+export const deleteTokens = () => {
+  localStorage.removeItem(ACCESS_TOKEN_KEY);
+  localStorage.removeItem(REFRESH_TOKEN_KEY);
+};
+
+export const postLogin = async (body: LoginArgs) => {
+  const response = await fetcher.post({
+    url: ENDPOINT.AUTH.LOGIN,
+    body,
+  });
+  return response;
+};
+
+export const getMe = async () => {
+  const accessToken = getAccessToken();
+  const response = await fetcher.get({
+    url: ENDPOINT.AUTH.ME,
+    headers: accessToken ? { Authorization: `Bearer ${accessToken}` } : {},
+  });
+  const data = await response.json();
+  return data as MeResponse;
+};
+
+export const postRegister = async (body: RegisterArgs) => {
+  const response = await fetcher.post({
+    url: ENDPOINT.AUTH.REGISTER,
+    body,
+  });
+  return response;
+};
+
+export const postVerifyBusinessNumber = async (
+  body: VerifyBusinessNumberArgs
+) => {
+  const response = await fetcher.post({
+    url: ENDPOINT.AUTH.VERIFY_BUSINESS_NUMBER,
+    body,
+  });
+  return response;
+};
+
+export const postReissueAccessToken = async () => {
+  const refreshToken = getRefreshToken() ?? "";
+  const response = await fetcher.post({
+    url: ENDPOINT.AUTH.REFRESH,
+    body: { refreshToken },
+  });
+  return response;
+};

--- a/src/apis/blog.ts
+++ b/src/apis/blog.ts
@@ -1,0 +1,47 @@
+import fetcher from "@/apis/fetcher";
+import { ENDPOINT } from "@/apis/url";
+import type {
+  BlogBanner,
+  BlogListResponse,
+  BlogDetailResponse,
+} from "@/types/blog";
+
+/** 블로그 배너 조회 */
+export const getBlogBanners = async () => {
+  const response = await fetcher.get({
+    url: ENDPOINT.BLOGS.BANNERS,
+  });
+  const data = await response.json();
+  return data as BlogBanner[];
+};
+
+/** 블로그 목록 조회 */
+export const getBlogList = async (params?: {
+  page?: number;
+  pageSize?: number;
+  category?: "NEWS" | "TIP" | "GUIDE" | "EXPERIENCE";
+  term?: string;
+}) => {
+  const searchParams = new URLSearchParams();
+  if (params?.page != null) searchParams.append("page", String(params.page));
+  if (params?.pageSize != null)
+    searchParams.append("pageSize", String(params.pageSize));
+  if (params?.category) searchParams.append("category", params.category);
+  if (params?.term) searchParams.append("term", params.term);
+
+  const qs = searchParams.toString();
+  const response = await fetcher.get({
+    url: `${ENDPOINT.BLOGS.LIST}${qs ? `?${qs}` : ""}`,
+  });
+  const data = await response.json();
+  return data as BlogListResponse;
+};
+
+/** 블로그 상세 조회 */
+export const getBlogDetail = async (id: number) => {
+  const response = await fetcher.get({
+    url: ENDPOINT.BLOGS.DETAIL(id),
+  });
+  const data = await response.json();
+  return data as BlogDetailResponse;
+};

--- a/src/apis/config.ts
+++ b/src/apis/config.ts
@@ -1,0 +1,1 @@
+export const API_URL = process.env.NEXT_PUBLIC_API_URL as string;

--- a/src/apis/error/APIError.ts
+++ b/src/apis/error/APIError.ts
@@ -1,0 +1,13 @@
+export default class APIError extends Error {
+  status: number;
+  code?: string;
+  raw?: unknown;
+
+  constructor(status: number, code?: string, message?: string, raw?: unknown) {
+    super(message || `HTTP ${status}`);
+    this.status = status;
+    this.code = code;
+    this.raw = raw;
+    Object.setPrototypeOf(this, APIError.prototype);
+  }
+}

--- a/src/apis/fetcher.ts
+++ b/src/apis/fetcher.ts
@@ -1,0 +1,135 @@
+import APIError from "@/apis/error/APIError";
+import { ENDPOINT } from "@/apis/url";
+import { ROUTE_PATH } from "@/shared/constants/routes";
+import { deleteTokens, postReissueAccessToken } from "@/apis/auth";
+
+type Method = "GET" | "POST" | "PATCH" | "PUT" | "DELETE";
+
+interface RequestProps {
+  url: string;
+  method: Method;
+  body?: object | object[];
+  headers?: Record<string, string>;
+  credentials?: RequestCredentials;
+  signal?: AbortSignal;
+}
+type FetchProps = Omit<RequestProps, "method">;
+
+let refreshPromise: Promise<Response> | null = null;
+
+const parseJsonSafe = async (res: Response) => {
+  try {
+    const text = await res.clone().text();
+    if (!text) return null;
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+};
+
+const rawFetch = (props: RequestProps) => {
+  const {
+    url,
+    method,
+    body,
+    headers = {},
+    credentials = "omit",
+    signal,
+  } = props;
+
+  const isGet = method === "GET";
+  const hasBody = body != null;
+
+  const hdr = new Headers(headers);
+  if (!isGet && hasBody && !hdr.has("Content-Type")) {
+    hdr.set("Content-Type", "application/json");
+  } else if (isGet && hdr.has("Content-Type")) {
+    hdr.delete("Content-Type");
+  }
+
+  return fetch(url, {
+    method,
+    credentials,
+    signal,
+    headers: hdr,
+    body: !isGet && hasBody ? JSON.stringify(body) : undefined,
+    cache: "no-store",
+  });
+};
+
+const request = async (requestProps: RequestProps) => {
+  try {
+    const res = await rawFetch(requestProps);
+    if (!res.ok) {
+      await handleError(res, requestProps);
+    }
+    return res;
+  } catch (err) {
+    if (err instanceof APIError) throw err;
+    throw new APIError(0, "NETWORK_ERROR", "네트워크 오류가 발생했습니다.");
+  }
+};
+
+const handleError = async (response: Response, requestProps: RequestProps) => {
+  const payload = await parseJsonSafe(response);
+  const errorCode = (payload as any)?.errorCode || (payload as any)?.code;
+  const errorMessage =
+    (payload as any)?.errorMessage || (payload as any)?.message;
+
+  if (response.status === 401) {
+    if (requestProps.url === ENDPOINT.AUTH.REFRESH) {
+      throw new APIError(401, errorCode, errorMessage, payload);
+    }
+    return handleUnauthorized(requestProps, errorCode, errorMessage, payload);
+  }
+
+  throw new APIError(response.status, errorCode, errorMessage, payload);
+};
+
+const handleUnauthorized = async (
+  originalReq: RequestProps,
+  code?: string,
+  message?: string,
+  raw?: unknown
+) => {
+  if (!refreshPromise) {
+    refreshPromise = postReissueAccessToken();
+  }
+
+  try {
+    const refreshRes = await refreshPromise;
+    refreshPromise = null;
+
+    if (refreshRes?.status === 200) {
+      return await rawFetch(originalReq);
+    }
+
+    throw new Error("refresh failed");
+  } catch {
+    refreshPromise = null;
+    await deleteTokens?.();
+    if (typeof window !== "undefined") {
+      window.location.href = ROUTE_PATH.root;
+    }
+    throw new APIError(401, code, message, raw);
+  }
+};
+
+const fetcher = {
+  get: ({ url, headers, signal, credentials }: FetchProps) =>
+    request({ url, method: "GET", headers, signal, credentials }),
+
+  post: ({ url, body, headers, signal, credentials }: FetchProps) =>
+    request({ url, method: "POST", body, headers, signal, credentials }),
+
+  patch: ({ url, body, headers, signal, credentials }: FetchProps) =>
+    request({ url, method: "PATCH", body, headers, signal, credentials }),
+
+  put: ({ url, body, headers, signal, credentials }: FetchProps) =>
+    request({ url, method: "PUT", body, headers, signal, credentials }),
+
+  delete: ({ url, headers, signal, credentials }: FetchProps) =>
+    request({ url, method: "DELETE", headers, signal, credentials }),
+};
+
+export default fetcher;

--- a/src/apis/url.ts
+++ b/src/apis/url.ts
@@ -1,0 +1,24 @@
+import { API_URL } from "./config";
+export const BASE_URL = API_URL;
+export const ENDPOINT = {
+  // Authentication
+  AUTH: {
+    LOGIN: `${API_URL}/api/auth/login`,
+    ME: `${API_URL}/api/auth/me`,
+    REGISTER: `${API_URL}/api/auth/register`,
+    VERIFY_BUSINESS_NUMBER: `${API_URL}/api/auth/verify-business-number`,
+    REFRESH: `${API_URL}/api/auth/refresh-token`,
+  },
+
+  // Blogs
+  BLOGS: {
+    BANNERS: `${API_URL}/api/blogs/banners`,
+    LIST: `${API_URL}/api/blogs`,
+    DETAIL: (id: string | number) => `${API_URL}/api/blogs/${id}`,
+  },
+
+  // Users
+  USERS: {
+    LIST: `${API_URL}/api/users`,
+  },
+};

--- a/src/components/footer/FooterCustomerService.tsx
+++ b/src/components/footer/FooterCustomerService.tsx
@@ -9,7 +9,7 @@ const FooterCustomerService = () => {
         </h3>
         <a
           href="tel:1811-1463"
-          className="font-mukta text-display-2 font-bold text-nowrap text-primary md:text-[44px] lg:text-display-1"
+          className="font-mukta  text-display-2 font-bold text-nowrap text-primary-500 md:text-[44px] lg:text-display-1"
         >
           1811-1463
         </a>

--- a/src/shared/constants/routes.ts
+++ b/src/shared/constants/routes.ts
@@ -1,0 +1,3 @@
+export const ROUTE_PATH = {
+  root: "/", // 홈
+} as const;

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,68 @@
+export interface LoginArgs {
+  businessNumber: string;
+  password: string;
+}
+
+export interface LoginResponse {
+  accessToken: string;
+  refreshToken: string;
+  accessTokenExpiresIn: number;
+  refreshTokenExpiresIn: number;
+}
+
+export interface MeUser {
+  id: number;
+  businessNumber: string;
+  userName: string;
+  companyName: string;
+  phone: string;
+  email: string;
+  birthDate: string;
+}
+
+export interface MeResponse {
+  user: MeUser;
+}
+
+export interface RegisterArgs {
+  businessNumber: string;
+  userName: string;
+  password: string;
+  companyName: string;
+  phone: string;
+  email: string;
+  partnerId?: string;
+  birthDate: string;
+  isMarketingConsent: boolean;
+  businessNumberVerifyToken: string;
+}
+
+export interface RegisterResponse {
+  success: boolean;
+  message: string;
+}
+
+export interface VerifyBusinessNumberArgs {
+  businessNumber: string;
+}
+
+export interface VerifyBusinessNumberResponse {
+  company: string;
+  owner: string;
+  businessNumberVerifyToken: string;
+}
+
+export interface RefreshTokenArgs {
+  refreshToken: string;
+}
+
+export interface RefreshTokenResponse {
+  accessToken: string;
+  refreshToken: string;
+  accessTokenExpiresIn: number;
+  refreshTokenExpiresIn: number;
+}
+export interface ApiErrorResponse {
+  errorCode: string;
+  errorMessage: string;
+}

--- a/src/types/blog.ts
+++ b/src/types/blog.ts
@@ -1,0 +1,41 @@
+// src/types/blog.ts
+
+export type BlogBanner = {
+  id: number;
+  title: string;
+  thumbnail: string;
+  summary: string;
+};
+
+export type BlogListItem = {
+  id: number;
+  title: string;
+  category: "NEWS" | "TIP" | "GUIDE" | "EXPERIENCE";
+  thumbnail: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type BlogListResponse = {
+  list: BlogListItem[];
+  totalCount: number;
+  totalPages: number;
+  page: number;
+  pageSize: number;
+};
+
+export type BlogDetailResponse = {
+  id: number;
+  category: "NEWS" | "TIP" | "GUIDE" | "EXPERIENCE";
+  title: string;
+  thumbnail: string;
+  summary: string;
+  content: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type ErrorResponse = {
+  errorCode: string;
+  errorMessage: string;
+};


### PR DESCRIPTION
## 변경 사항
- API 레이어 구축
  - `src/apis/fetcher.ts`: 공통 fetcher 추가(헤더 자동 설정, 안전 JSON 파싱, 401 처리/토큰 리프레시, NETWORK_ERROR 표준화)
  - `src/apis/error/APIError.ts`: 표준 예외 클래스 도입
  - `src/apis/config.ts`: `API_URL` 환경변수 래퍼
  - `src/apis/url.ts`: 엔드포인트 상수화
  - `src/shared/constants/routes.ts`: 라우트 상수(`root`) 추가
- 인증 API 추가
  - `postLogin`, `getMe`, `postRegister`, `postVerifyBusinessNumber`, `postReissueAccessToken`
  - 토큰 유틸: `saveTokens / getAccessToken / getRefreshToken / deleteTokens`
  - 타입 정의: `src/types/auth.ts`
- 블로그 API 추가
  - `getBlogBanners`, `getBlogList`(쿼리 파라미터 지원), `getBlogDetail`
  - 타입 정의: `src/types/blog.ts`
- UI 보완
  - `FooterCustomerService`: 전화번호 색상 `text-primary` → `text-primary-500`로 조정
