### PR TITLE
feat: 하단 밑줄 애니메이션이 있는 카테고리 탭 추가

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import { Search, CircleX } from "lucide-react";
 import { getBlogBanners } from "@/apis/blog";
 import BannerCarousel from "@/components/blog/BannerCarousel";
 import DesktopBanners from "@/components/blog/DesktopBanners";
+import CategoryTabs from "@/components/blog/CategoryTabs";
 
 export default async function Home() {
   const banners = await getBlogBanners();
@@ -32,6 +33,9 @@ export default async function Home() {
       <section className="mt-8 md:mt-10">
         <BannerCarousel banners={banners} />
         <DesktopBanners banners={banners} />
+      </section>
+      <section className="mt-8 md:mt-10 lg:mt-11">
+        <CategoryTabs />
       </section>
     </article>
   );

--- a/src/components/blog/CategoryTabs.tsx
+++ b/src/components/blog/CategoryTabs.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useState, useRef } from "react";
+import { Button } from "@/shared/button/Button";
+import { motion, AnimatePresence } from "framer-motion";
+
+const categories = [
+  { id: "all", label: "전체" },
+  { id: "trend", label: "트렌드" },
+  { id: "tips", label: "운영 팁" },
+  { id: "guide", label: "올라가이드" },
+  { id: "news", label: "올라소식" },
+  { id: "case", label: "고객사례" },
+];
+
+export default function CategoryTabs() {
+  const [activeCategory, setActiveCategory] = useState("all");
+  const [activeButtonRect, setActiveButtonRect] = useState<DOMRect | null>(
+    null
+  );
+  const buttonRefs = useRef<{ [key: string]: HTMLButtonElement | null }>({});
+
+  const handleCategoryClick = (categoryId: string) => {
+    setActiveCategory(categoryId);
+
+    const buttonElement = buttonRefs.current[categoryId];
+    if (buttonElement) {
+      const rect = buttonElement.getBoundingClientRect();
+      const containerRect = buttonElement
+        .closest(".scrollbar-hide")
+        ?.getBoundingClientRect();
+
+      if (containerRect) {
+        setActiveButtonRect({
+          ...rect,
+          left: rect.left - containerRect.left,
+          width: rect.width,
+        });
+      }
+    }
+  };
+
+  return (
+    <div className="scrollbar-hide flex items-center  border-b border-b-line-200 relative">
+      <AnimatePresence>
+        {activeButtonRect && (
+          <motion.div
+            className="absolute bottom-0 h-[2px] bg-label-900"
+            style={{ transform: "none", transformOrigin: "50% 50% 0px" }}
+            initial={{
+              x: activeButtonRect.left,
+              width: activeButtonRect.width,
+            }}
+            animate={{
+              x: activeButtonRect.left,
+              width: activeButtonRect.width,
+            }}
+            transition={{ duration: 0.3, ease: "easeInOut" }}
+          />
+        )}
+      </AnimatePresence>
+
+      {categories.map((category) => (
+        <div key={category.id} className="relative">
+          <Button
+            ref={(el) => {
+              buttonRefs.current[category.id] = el;
+            }}
+            className={`text-body-1 whitespace-nowrap py-[15px] px-5 relative font-semibold ${
+              activeCategory === category.id
+                ? "text-label-900"
+                : "text-label-500"
+            }`}
+            onClick={() => handleCategoryClick(category.id)}
+          >
+            {category.label}
+          </Button>
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## 변경 사항
- 카테고리 탭 도입
  - `src/components/blog/CategoryTabs.tsx` 추가(클라이언트 컴포넌트)
  - `framer-motion`의 `AnimatePresence/motion.div`로 활성 탭 하단 인디케이터 애니메이션
  - `Button` + ref 측정(`getBoundingClientRect`)으로 인디케이터 위치/너비 동기화
  - 초기 활성값 `all`, 스크롤 숨김 바텀 보더(`border-b-line-200`) 적용
- 홈 페이지 연동
  - `app/page.tsx` 배너 섹션 하단에 카테고리 섹션 추가(`CategoryTabs` 렌더)
  - 섹션 간 마진(`mt-8 md:mt-10 lg:mt-11`) 적용






