### PR TITLE
feat: signup-page 완성

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@next/font": "^14.2.15",
+        "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-slot": "^1.2.3",
         "@tanstack/react-query": "^5.85.5",
         "@tanstack/react-query-devtools": "^5.85.5",
@@ -21,6 +22,7 @@
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-error-boundary": "^6.0.0",
+        "react-hook-form": "^7.62.0",
         "tailwind-merge": "^3.3.1",
         "tailwindcss-animate": "^1.0.7"
       },
@@ -1112,6 +1114,42 @@
         "node": ">=14"
       }
     },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz",
+      "integrity": "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
@@ -1127,6 +1165,68 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
@@ -1134,6 +1234,91 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1277,7 +1462,7 @@
       "version": "19.1.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.7.tgz",
       "integrity": "sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
@@ -5521,6 +5706,22 @@
       },
       "peerDependencies": {
         "react": ">=16.13.1"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.62.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.62.0.tgz",
+      "integrity": "sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@next/font": "^14.2.15",
+    "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-slot": "^1.2.3",
     "@tanstack/react-query": "^5.85.5",
     "@tanstack/react-query-devtools": "^5.85.5",
@@ -22,6 +23,7 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-error-boundary": "^6.0.0",
+    "react-hook-form": "^7.62.0",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7"
   },

--- a/src/app/sign-up/page.tsx
+++ b/src/app/sign-up/page.tsx
@@ -1,0 +1,137 @@
+"use client";
+import { useState, useEffect } from "react";
+import { useForm, FormProvider } from "react-hook-form";
+import {
+  AgreementStep,
+  BusinessStep,
+  CompanyInfoStep,
+} from "@/components/sign-up";
+
+interface SignUpFormData {
+  businessNumber: string;
+  password: string;
+  passwordConfirm: string;
+}
+
+export default function SignUpPage() {
+  const [progress, setProgress] = useState(0);
+  const [currentStep, setCurrentStep] = useState<
+    "agreement" | "business" | "companyInfo"
+  >("agreement");
+  const [showFixedProgress, setShowFixedProgress] = useState(false);
+
+  const methods = useForm<SignUpFormData>({
+    defaultValues: {
+      businessNumber: "",
+      password: "",
+      passwordConfirm: "",
+    },
+    mode: "onChange", // 입력하는 동안 실시간 유효성 검사
+  });
+
+  const handleProgressUpdate = (newProgress: number) => {
+    // 약관 동의 완료 시 15% 기본 설정
+    setProgress(15);
+    // 약관 동의 완료 후 다음 단계로 이동
+    setCurrentStep("business");
+  };
+
+  // 스크롤 감지하여 고정 프로그레스바 표시/숨김
+  useEffect(() => {
+    const handleScroll = () => {
+      const progressSection = document.getElementById("progress-section");
+
+      if (progressSection) {
+        const progressRect = progressSection.getBoundingClientRect();
+        // 프로그레스바가 화면에서 사라지면 고정 프로그레스바 표시
+        setShowFixedProgress(progressRect.bottom < 0);
+      }
+    };
+
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  return (
+    <FormProvider {...methods}>
+      <article className=" max-md:container pb-10 relative mx-auto max-w-[520px] md:px-7 space-y-8">
+        <header>
+          <h1 className="text-center text-title-2 md:text-title-1 lg:text-display-2">
+            지금 회원가입하면
+            <br />
+            <span className="font-bold">수수료 지원금 3만원 지급!</span>
+          </h1>
+        </header>
+        <section id="progress-section">
+          <div className="relative space-y-0 sm:space-y-2">
+            <div className="flex items-center justify-between">
+              <div className="absolute bottom-0  z-0 h-[100px] w-[10px]"></div>
+              <span className="text-primary relative z-10 text-body-3 font-normal md:text-body-2">
+                최대 1,250만원까지 무료 선정산이 가능해요.
+              </span>
+              <span className="text-primary text-body-3 font-medium md:text-body-2 md:font-semibold">
+                {progress}%
+              </span>
+            </div>
+            <div
+              aria-valuemax={100}
+              aria-valuemin={0}
+              role="progressbar"
+              data-state="indeterminate"
+              data-max="100"
+              className="h-5 w-full overflow-hidden rounded-2xl bg-background-alternative relative space-y-0 sm:space-y-2"
+            >
+              <div
+                data-state="indeterminate"
+                data-max="100"
+                className="size-full flex-1 rounded-2xl bg-primary transition-all duration-500 relative space-y-0 sm:space-y-2"
+                style={{ transform: `translateX(-${100 - progress}%)` }}
+              ></div>
+            </div>
+            <div
+              className="fixed top-[60px] left-0 z-50 h-4 w-[100dvw] overflow-hidden bg-label-200 transition-opacity duration-300"
+              style={{ opacity: showFixedProgress ? 1 : 0 }}
+            >
+              <div
+                className="absolute top-0 left-0 h-full bg-primary transition-all duration-300"
+                style={{ width: `${progress}%` }}
+              ></div>
+              <div className="fixed top-[80px] left-1/2 z-50 h-5 w-[80%] max-w-[520px] -translate-x-1/2">
+                <div className="flex justify-between rounded-lg bg-background-default px-7 py-6 text-primary shadow-strong">
+                  <span className="text-body-3 font-normal md:text-body-2">
+                    최대 1,250만원까지 무료 선정산이 가능해요.
+                  </span>
+                  <span className="text-body-3 font-medium md:text-body-2 md:font-semibold">
+                    {progress}%
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {currentStep === "agreement" && (
+          <section>
+            <AgreementStep onComplete={handleProgressUpdate} />
+          </section>
+        )}
+
+        {currentStep === "business" && (
+          <section>
+            <BusinessStep
+              onComplete={(progress) => {
+                setProgress(progress);
+              }}
+            />
+          </section>
+        )}
+
+        {currentStep === "companyInfo" && (
+          <section>
+            <CompanyInfoStep />
+          </section>
+        )}
+      </article>
+    </FormProvider>
+  );
+}

--- a/src/components/blog/CategoryTabs.tsx
+++ b/src/components/blog/CategoryTabs.tsx
@@ -52,6 +52,7 @@ export default function CategoryTabs({ value, onChange }: CategoryTabsProps) {
       {categories.map((category) => (
         <div key={category.id} className="relative">
           <Button
+            variant="ghost"
             ref={(el) => registerButtonRef(category.id, el)}
             className={`text-body-1 whitespace-nowrap py-[15px] px-5 relative font-semibold ${
               value === category.id ? "text-label-900" : "text-label-500"

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -1,9 +1,19 @@
+"use client";
+
 import React from "react";
+import { usePathname } from "next/navigation";
 import FooterLogo from "./FooterLogo";
 import FooterCompanyLogos from "./FooterCompanyLogos";
 import FooterCustomerService from "./FooterCustomerService";
 
 const Footer = () => {
+  const pathname = usePathname();
+
+  // 회원가입 페이지에서는 푸터 숨김
+  if (pathname.startsWith("/sign-up")) {
+    return null;
+  }
+
   return (
     <footer className="w-full bg-background-default h-[358px]">
       <div className="shrink-0 h-px w-full bg-line-200"></div>

--- a/src/components/header/HeaderDesktopActions.tsx
+++ b/src/components/header/HeaderDesktopActions.tsx
@@ -5,13 +5,13 @@ const HeaderDesktopActions = () => {
   return (
     <div className="flex items-center gap-4 max-lg:hidden">
       <Link
-        href="/"
+        href="/sign-up"
         className="inline-flex items-center justify-center whitespace-nowrap cursor-pointer disabled:cursor-not-allowed border border-secondary-300 bg-background-default text-primary hover:border-secondary-300 hover:bg-label-100 active:bg-background-alternative disabled:border-status-disable disabled:bg-background-default disabled:text-status-disable h-[32px] gap-1 rounded-sm px-6 text-body-3 font-medium"
       >
         회원가입
       </Link>
       <Link
-        href="/"
+        href="/login"
         className="inline-flex items-center justify-center whitespace-nowrap cursor-pointer disabled:cursor-not-allowed border bg-background-default text-label-800 hover:bg-label-100 active:bg-background-alternative disabled:border-line-400 disabled:text-status-disable h-[32px] gap-1 rounded-sm px-6 text-body-3 font-medium"
       >
         로그인

--- a/src/components/header/HeaderMobileActions.tsx
+++ b/src/components/header/HeaderMobileActions.tsx
@@ -6,7 +6,7 @@ const HeaderMobileActions = () => {
   return (
     <div className="flex items-center gap-4 lg:hidden">
       <Link
-        href="/"
+        href="/sign-up"
         className="inline-flex items-center justify-center whitespace-nowrap cursor-pointer disabled:cursor-not-allowed border border-secondary-300 bg-background-default text-primary hover:border-secondary-300 hover:bg-label-100 active:bg-background-alternative disabled:border-status-disable disabled:bg-background-default disabled:text-status-disable h-[32px] gap-1 rounded-sm px-6 text-body-3 font-medium"
       >
         로그인/회원가입

--- a/src/components/layout/FooterWrapper.tsx
+++ b/src/components/layout/FooterWrapper.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import Footer from "@/components/footer/Footer";
+
+export default function FooterWrapper() {
+  const pathname = usePathname();
+  const showFooter = !pathname.startsWith("/sign-up");
+
+  if (!showFooter) {
+    return null;
+  }
+
+  return <Footer />;
+}

--- a/src/components/sign-up/AgreementCheckbox.tsx
+++ b/src/components/sign-up/AgreementCheckbox.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import * as Checkbox from "@radix-ui/react-checkbox";
+import { Check } from "lucide-react";
+
+interface AgreementCheckboxProps {
+  id: string;
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  label: string;
+  required?: boolean;
+}
+
+export function AgreementCheckbox({
+  id,
+  checked,
+  onCheckedChange,
+  label,
+  required = false,
+}: AgreementCheckboxProps) {
+  return (
+    <div className="flex items-center gap-3">
+      <Checkbox.Root
+        id={id}
+        checked={checked}
+        onCheckedChange={(checked) => onCheckedChange(checked as boolean)}
+        className="w-[20px] h-[20px] rounded border-2 border-gray-300 flex items-center justify-center hover:border-primary transition-colors data-[state=checked]:bg-primary data-[state=checked]:border-primary"
+        required={required}
+      >
+        <Checkbox.Indicator>
+          <Check className="w-4 h-4 text-white" />
+        </Checkbox.Indicator>
+      </Checkbox.Root>
+      <label htmlFor={id} className="text-body-2 cursor-pointer">
+        {label}
+        {required && <span className="text-red-500"> (필수)</span>}
+      </label>
+    </div>
+  );
+}

--- a/src/components/sign-up/AgreementHeader.tsx
+++ b/src/components/sign-up/AgreementHeader.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import * as Checkbox from "@radix-ui/react-checkbox";
+import { Check } from "lucide-react";
+
+interface AgreementHeaderProps {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}
+
+export function AgreementHeader({
+  checked,
+  onCheckedChange,
+}: AgreementHeaderProps) {
+  return (
+    <>
+      <div className="flex items-center gap-4">
+        <Checkbox.Root
+          id="all"
+          checked={checked}
+          onCheckedChange={onCheckedChange}
+          className="w-[20px] h-[20px] rounded border-2 border-gray-300 flex items-center justify-center hover:border-primary transition-colors data-[state=checked]:bg-primary data-[state=checked]:border-primary"
+        >
+          <Checkbox.Indicator>
+            <Check className="w-4 h-4 text-white" />
+          </Checkbox.Indicator>
+        </Checkbox.Root>
+        <label htmlFor="all" className="text-body-2 font-medium cursor-pointer">
+          전체 동의
+        </label>
+      </div>
+      <div
+        data-orientation="horizontal"
+        role="none"
+        className="shrink-0 h-px w-full bg-line-400 my-7"
+      ></div>
+    </>
+  );
+}

--- a/src/components/sign-up/AgreementList.tsx
+++ b/src/components/sign-up/AgreementList.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { AgreementCheckbox } from "./AgreementCheckbox";
+import { AGREEMENT_ITEMS } from "@/components/sign-up/constants/agreementItems";
+
+interface AgreementListProps {
+  agreements: Record<string, boolean>;
+  onAgreementChange: (key: string, checked: boolean) => void;
+}
+
+export function AgreementList({
+  agreements,
+  onAgreementChange,
+}: AgreementListProps) {
+  return (
+    <div className="flex flex-col gap-7">
+      {AGREEMENT_ITEMS.map((item) => (
+        <AgreementCheckbox
+          key={item.id}
+          id={item.id}
+          checked={agreements[item.id]}
+          onCheckedChange={(checked) => onAgreementChange(item.id, checked)}
+          label={item.label}
+          required={item.required}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/sign-up/AgreementStep.tsx
+++ b/src/components/sign-up/AgreementStep.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { Button } from "@/shared/button/Button";
+import { AgreementHeader } from "./AgreementHeader";
+import { AgreementList } from "./AgreementList";
+import { useAgreementStep } from "@/hooks/sign-up/useAgreementStep";
+
+interface AgreementStepProps {
+  onComplete: (percentage: number) => void;
+}
+
+export function AgreementStep({ onComplete }: AgreementStepProps) {
+  const {
+    agreements,
+    canProceed,
+    validation,
+    handleAllAgreement,
+    handleIndividualAgreement,
+  } = useAgreementStep();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onComplete(validation.progress);
+  };
+
+  return (
+    <form className="space-y-6" onSubmit={handleSubmit}>
+      <h2 className="text-title-3 font-bold">약관 동의</h2>
+
+      <AgreementHeader
+        checked={agreements.all}
+        onCheckedChange={handleAllAgreement}
+      />
+
+      <AgreementList
+        agreements={agreements}
+        onAgreementChange={handleIndividualAgreement}
+      />
+
+      <div className="mt-12 flex w-full flex-col">
+        <Button
+          type="submit"
+          disabled={!canProceed}
+          className="w-full h-12 rounded-lg"
+          size="lg"
+          variant={canProceed ? "default" : "secondary"}
+        >
+          다음
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/sign-up/BusinessNumberField.tsx
+++ b/src/components/sign-up/BusinessNumberField.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { Input } from "@/shared/input/Input";
+import { Button } from "@/shared/button/Button";
+import { UseFormRegister, FieldErrors } from "react-hook-form";
+
+interface BusinessNumberFieldProps {
+  register: UseFormRegister<any>;
+  errors: FieldErrors<any>;
+  businessNumber: string;
+  isVerified: boolean;
+  onVerify: () => void;
+}
+
+export function BusinessNumberField({
+  register,
+  errors,
+  businessNumber,
+  isVerified,
+  onVerify,
+}: BusinessNumberFieldProps) {
+  return (
+    <div className="space-y-0">
+      <div className="flex items-center justify-between">
+        <label
+          className="peer-disabled:cursor-not-allowed peer-disabled:text-status-disable text-body-3 font-medium text-label-700 py-0"
+          htmlFor="businessNumber"
+        >
+          사업자등록번호 (ID)
+        </label>
+        <a
+          href="https://www.ftc.go.kr/www/selectBizCommList.do?key=253&token=71FB05C5-4829-80F4-C230-B0FB890B3E892EB62DA22EDEFB1080D78429A22093C1"
+          className="inline-flex items-center justify-center whitespace-nowrap cursor-pointer disabled:cursor-not-allowed p-0! underline underline-offset-4 hover:bg-label-100 active:bg-background-alternative disabled:text-status-disable h-[32px] gap-1 rounded-sm px-6 text-body-3 font-medium text-label-700"
+        >
+          사업자 번호가 기억나지 않아요
+        </a>
+      </div>
+      <div className="flex items-stretch gap-4">
+        <div className="flex-1">
+          <Input
+            placeholder="-제외 10자리 입력"
+            id="businessNumber"
+            className={`w-full h-[48px] rounded-lg px-6 text-body-2 placeholder:text-body-2 border-2 ${
+              errors.businessNumber ? "border-red-500" : "border-gray-300"
+            } transition-colors`}
+            {...register("businessNumber", {
+              required: "사업자등록번호를 입력해 주세요.",
+              pattern: {
+                value: /^\d{10}$/,
+                message: "사업자등록번호 10자리를 입력해 주세요.",
+              },
+            })}
+          />
+          {errors.businessNumber && (
+            <p className="text-red-600 text-body-3 mt-2">
+              {errors.businessNumber.message as string}
+            </p>
+          )}
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          className={`h-[48px] rounded-lg px-6 border-primary min-w-[96px] transition-all ${
+            !businessNumber || businessNumber.length !== 10
+              ? "border-gray-300 text-gray-400 cursor-not-allowed"
+              : "text-primary cursor-pointer hover:bg-primary hover:text-white"
+          }`}
+          onClick={onVerify}
+          disabled={!businessNumber || businessNumber.length !== 10}
+        >
+          인증하기
+        </Button>
+      </div>
+
+      {/* 인증 완료 메시지 */}
+      {isVerified && (
+        <p className="mt-2 text-caption-1 text-status-correct">
+          사업자등록번호 확인이 완료되었어요
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/sign-up/BusinessStep.tsx
+++ b/src/components/sign-up/BusinessStep.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { Button } from "@/shared/button/Button";
+import { BusinessNumberField } from "./BusinessNumberField";
+import { PasswordFields } from "./PasswordFields";
+import { CompanyInfoStep } from "./CompanyInfoStep";
+import { useBusinessStep } from "@/hooks/sign-up/useBusinessStep";
+
+interface BusinessStepProps {
+  onComplete: (progress: number) => void;
+}
+
+export function BusinessStep({ onComplete }: BusinessStepProps) {
+  const {
+    register,
+    handleSubmit,
+    errors,
+    businessNumber,
+    password,
+    passwordConfirm,
+    isVerified,
+    canSubmit,
+    onSubmit,
+    handleVerify,
+  } = useBusinessStep({ onComplete });
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <div className="flex flex-col gap-6 mt-8">
+        <BusinessNumberField
+          register={register}
+          errors={errors}
+          businessNumber={businessNumber}
+          isVerified={isVerified}
+          onVerify={() => handleVerify(businessNumber)}
+        />
+
+        <PasswordFields
+          register={register}
+          errors={errors}
+          password={password}
+          passwordConfirm={passwordConfirm}
+        />
+
+        {/* 인증 완료 시 회사 정보 표시 */}
+        {isVerified && <CompanyInfoStep />}
+      </div>
+
+      <div className="mt-12 flex w-full flex-col">
+        <Button
+          type="submit"
+          className="w-full h-12 rounded-lg transition-all duration-300"
+          size="lg"
+          disabled={!canSubmit}
+          variant={canSubmit ? "default" : "secondary"}
+        >
+          가입하기
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/sign-up/CompanyInfoField.tsx
+++ b/src/components/sign-up/CompanyInfoField.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { Input } from "@/shared/input/Input";
+import {
+  UseFormRegister,
+  FieldErrors,
+  UseFormSetValue,
+  UseFormWatch,
+} from "react-hook-form";
+
+interface CompanyInfoFieldProps {
+  id: string;
+  label: string;
+  placeholder: string;
+  type?: string;
+  required?: boolean;
+  disabled?: boolean;
+  value?: string;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  maxLength?: number;
+  pattern?: {
+    value: RegExp;
+    message: string;
+  };
+  register: UseFormRegister<any>;
+  errors: FieldErrors<any>;
+  setValue?: UseFormSetValue<any>;
+  watch?: UseFormWatch<any>;
+}
+
+export function CompanyInfoField({
+  id,
+  label,
+  placeholder,
+  type = "text",
+  required = false,
+  disabled = false,
+  value,
+  onChange,
+  maxLength,
+  pattern,
+  register,
+  errors,
+  setValue,
+  watch,
+}: CompanyInfoFieldProps) {
+  const hasError = errors[id];
+
+  if (disabled) {
+    return (
+      <div className="space-y-3">
+        <label
+          className="peer-disabled:cursor-not-allowed peer-disabled:text-status-disable text-body-3 font-medium text-label-700"
+          htmlFor={id}
+        >
+          {label}
+        </label>
+        <div className="h-[48px] rounded-lg px-6 text-body-2 border-2 border-gray-300 bg-gray-50 flex items-center justify-between cursor-not-allowed group">
+          <span className="text-gray-600">{value}</span>
+        </div>
+      </div>
+    );
+  }
+
+  const inputProps = {
+    className: `h-[48px] rounded-lg px-6 text-body-2 placeholder:text-body-2 border-2 ${
+      hasError ? "border-red-500" : "border-gray-300"
+    } transition-colors`,
+    placeholder,
+    id,
+    type,
+    maxLength,
+    ...(onChange && { onChange }),
+    ...register(id, {
+      required: required ? `${label}을(를) 입력해 주세요.` : false,
+      pattern: pattern,
+    }),
+  };
+
+  return (
+    <div className="space-y-3">
+      <label
+        className="peer-disabled:cursor-not-allowed peer-disabled:text-status-disable text-body-3 font-medium text-label-700"
+        htmlFor={id}
+      >
+        {label}
+      </label>
+      <Input {...inputProps} />
+      {hasError && (
+        <p className="text-red-600 text-body-3 mt-2">
+          {hasError.message as string}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/sign-up/CompanyInfoStep.tsx
+++ b/src/components/sign-up/CompanyInfoStep.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { CompanyInfoField } from "./CompanyInfoField";
+import { COMPANY_INFO_FIELDS } from "./constants/companyInfoFields";
+import { useCompanyInfoStep } from "@/hooks/sign-up/useCompanyInfoStep";
+
+export function CompanyInfoStep() {
+  const { register, errors, phoneNumber, handlePhoneNumberChange } =
+    useCompanyInfoStep();
+
+  return (
+    <div className="space-y-4">
+      {COMPANY_INFO_FIELDS.map((field) => (
+        <CompanyInfoField
+          key={field.id}
+          {...field}
+          register={register}
+          errors={errors}
+          value={
+            field.id === "companyName"
+              ? "올라핀테크"
+              : field.id === "phoneNumber"
+              ? phoneNumber
+              : undefined
+          }
+          onChange={
+            field.id === "phoneNumber" ? handlePhoneNumberChange : undefined
+          }
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/sign-up/PasswordFields.tsx
+++ b/src/components/sign-up/PasswordFields.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { Input } from "@/shared/input/Input";
+import { UseFormRegister, FieldErrors } from "react-hook-form";
+
+interface PasswordFieldsProps {
+  register: UseFormRegister<any>;
+  errors: FieldErrors<any>;
+  password: string;
+  passwordConfirm: string;
+}
+
+export function PasswordFields({
+  register,
+  errors,
+  password,
+  passwordConfirm,
+}: PasswordFieldsProps) {
+  return (
+    <div className="space-y-4">
+      <div className="space-y-3">
+        <label
+          className="peer-disabled:cursor-not-allowed peer-disabled:text-status-disable text-body-3 font-medium text-label-700"
+          htmlFor="password"
+        >
+          비밀번호
+        </label>
+        <div>
+          <Input
+            className={`h-[48px] rounded-lg px-6 text-body-2 placeholder:text-body-2 border-2 ${
+              errors.password ? "border-red-500" : "border-gray-300"
+            } transition-colors`}
+            placeholder="8~15자리/영문, 숫자, 특수문자 조합 입력"
+            id="password"
+            type="password"
+            {...register("password", {
+              required: "비밀번호를 입력해 주세요.",
+              pattern: {
+                value:
+                  /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,15}$/,
+                message:
+                  "8~15자리 영문, 숫자, 특수문자로 조합하여 입력해주세요",
+              },
+            })}
+          />
+          {errors.password && (
+            <p className="text-red-600 text-body-3 mt-2">
+              {errors.password.message as string}
+            </p>
+          )}
+        </div>
+        <div className="space-y-3">
+          <div className="realative w-full">
+            <Input
+              className={`h-[48px] rounded-lg px-6 text-body-2 placeholder:text-body-2 border-2 ${
+                errors.passwordConfirm ? "border-red-500" : "border-gray-300"
+              } transition-colors`}
+              placeholder="8~15자리/영문, 숫자, 특수문자 조합 재입력"
+              id="passwordConfirm"
+              type="password"
+              {...register("passwordConfirm", {
+                required: "비밀번호 확인을 입력해 주세요.",
+                validate: (value, formValues) => {
+                  return (
+                    value === formValues.password ||
+                    "비밀번호가 일치하지 않습니다."
+                  );
+                },
+              })}
+            />
+            {errors.passwordConfirm && (
+              <p className="text-red-600 text-body-3 mt-2">
+                {errors.passwordConfirm.message as string}
+              </p>
+            )}
+
+            {/* 비밀번호 사용 가능 메시지 */}
+            {!errors.password &&
+              !errors.passwordConfirm &&
+              password &&
+              passwordConfirm &&
+              password === passwordConfirm && (
+                <p className="mt-2 text-caption-1 text-status-correct">
+                  사용 가능한 비밀번호에요
+                </p>
+              )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/sign-up/constants/agreementItems.ts
+++ b/src/components/sign-up/constants/agreementItems.ts
@@ -1,0 +1,47 @@
+export interface AgreementItem {
+  id: string;
+  label: string;
+  required: boolean;
+  description?: string;
+}
+
+export const AGREEMENT_ITEMS: AgreementItem[] = [
+  {
+    id: "service",
+    label: "서비스 이용약관 동의",
+    required: true,
+    description: "서비스 이용에 필요한 기본 약관에 동의합니다.",
+  },
+  {
+    id: "privacy",
+    label: "개인(신용)정보 수집 및 이용동의",
+    required: true,
+    description: "개인정보 수집 및 이용에 대한 동의입니다.",
+  },
+  {
+    id: "provision",
+    label: "개인(신용)정보 제공 및 위탁동의",
+    required: true,
+    description: "개인정보 제공 및 위탁에 대한 동의입니다.",
+  },
+  {
+    id: "inquiry",
+    label: "개인(신용)정보 조회 동의",
+    required: true,
+    description: "개인정보 조회에 대한 동의입니다.",
+  },
+  {
+    id: "marketing",
+    label: "마케팅 활용 및 광고성 정보 수신동의",
+    required: false,
+    description:
+      "마케팅 목적으로 개인정보를 활용하고 광고성 정보를 수신하는 것에 대한 동의입니다.",
+  },
+];
+
+export const REQUIRED_AGREEMENT_IDS = [
+  "service",
+  "privacy",
+  "provision",
+  "inquiry",
+] as string[];

--- a/src/components/sign-up/constants/companyInfoFields.ts
+++ b/src/components/sign-up/constants/companyInfoFields.ts
@@ -1,0 +1,66 @@
+export interface CompanyInfoFieldConfig {
+  id: string;
+  label: string;
+  placeholder: string;
+  type: string;
+  required: boolean;
+  disabled: boolean;
+  maxLength?: number;
+  pattern?: {
+    value: RegExp;
+    message: string;
+  };
+}
+
+export const COMPANY_INFO_FIELDS: CompanyInfoFieldConfig[] = [
+  {
+    id: "companyName",
+    label: "상호명",
+    placeholder: "올라핀테크",
+    type: "text",
+    required: false,
+    disabled: true,
+  },
+  {
+    id: "representativeName",
+    label: "대표자",
+    placeholder: "김올라",
+    type: "text",
+    required: true,
+    disabled: false,
+  },
+  {
+    id: "birthDate",
+    label: "대표자 생년월일",
+    placeholder: "생년월일 8자리 입력 (19900101)",
+    type: "text",
+    required: true,
+    disabled: false,
+    maxLength: 8,
+    pattern: {
+      value: /^\d{8}$/,
+      message: "생년월일 8자리를 입력해 주세요.",
+    },
+  },
+  {
+    id: "phoneNumber",
+    label: "대표자 휴대폰 번호",
+    placeholder: "계약서 송부를 위해 꼭 본인정보 입력",
+    type: "text",
+    required: true,
+    disabled: false,
+    maxLength: 13,
+  },
+  {
+    id: "email",
+    label: "대표자 이메일",
+    placeholder: "이메일 입력",
+    type: "email",
+    required: true,
+    disabled: false,
+    pattern: {
+      value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+      message: "올바른 이메일 형식을 입력해 주세요.",
+    },
+  },
+];

--- a/src/components/sign-up/index.ts
+++ b/src/components/sign-up/index.ts
@@ -1,0 +1,9 @@
+export { AgreementStep } from "./AgreementStep";
+export { AgreementHeader } from "./AgreementHeader";
+export { AgreementList } from "./AgreementList";
+export { AgreementCheckbox } from "./AgreementCheckbox";
+export { BusinessStep } from "./BusinessStep";
+export { BusinessNumberField } from "./BusinessNumberField";
+export { PasswordFields } from "./PasswordFields";
+export { CompanyInfoStep } from "./CompanyInfoStep";
+export { CompanyInfoField } from "./CompanyInfoField";

--- a/src/hooks/sign-up/agreementValidation.ts
+++ b/src/hooks/sign-up/agreementValidation.ts
@@ -1,0 +1,52 @@
+import { REQUIRED_AGREEMENT_IDS } from "../../components/sign-up/constants/agreementItems";
+
+export interface AgreementValidationResult {
+  isValid: boolean;
+  missingAgreements: string[];
+  progress: number;
+}
+
+export function validateAgreements(
+  agreements: Record<string, boolean>
+): AgreementValidationResult {
+  const missingAgreements = REQUIRED_AGREEMENT_IDS.filter(
+    (id) => !agreements[id]
+  );
+
+  const isValid = missingAgreements.length === 0;
+  const progress = Math.round(
+    ((REQUIRED_AGREEMENT_IDS.length - missingAgreements.length) /
+      REQUIRED_AGREEMENT_IDS.length) *
+      100
+  );
+
+  return {
+    isValid,
+    missingAgreements,
+    progress,
+  };
+}
+
+export function checkAllAgreements(
+  agreements: Record<string, boolean>
+): boolean {
+  return REQUIRED_AGREEMENT_IDS.every((id) => agreements[id]);
+}
+
+export function getAgreementSummary(agreements: Record<string, boolean>) {
+  const requiredCount = REQUIRED_AGREEMENT_IDS.length;
+  const optionalCount = Object.keys(agreements).length - requiredCount;
+
+  const checkedRequired = REQUIRED_AGREEMENT_IDS.filter(
+    (id) => agreements[id]
+  ).length;
+  const checkedOptional = Object.keys(agreements)
+    .filter((id) => !REQUIRED_AGREEMENT_IDS.includes(id))
+    .filter((id) => agreements[id]).length;
+
+  return {
+    required: { total: requiredCount, checked: checkedRequired },
+    optional: { total: optionalCount, checked: checkedOptional },
+    totalProgress: Math.round((checkedRequired / requiredCount) * 100),
+  };
+}

--- a/src/hooks/sign-up/index.ts
+++ b/src/hooks/sign-up/index.ts
@@ -1,0 +1,12 @@
+export { useAgreementStep } from "./useAgreementStep";
+export { useCompanyInfoStep } from "./useCompanyInfoStep";
+export { useBusinessStep } from "./useBusinessStep";
+export { useProgressCalculation } from "./useProgressCalculation";
+export { useBusinessVerification } from "./useBusinessVerification";
+export { useRegistration } from "./useRegistration";
+export {
+  validateAgreements,
+  checkAllAgreements,
+  getAgreementSummary,
+} from "./agreementValidation";
+export { AGREEMENT_ITEMS } from "../../components/sign-up/constants/agreementItems";

--- a/src/hooks/sign-up/useAgreementStep.ts
+++ b/src/hooks/sign-up/useAgreementStep.ts
@@ -1,0 +1,76 @@
+import { useState, useCallback, useMemo } from "react";
+import { validateAgreements, checkAllAgreements } from "./agreementValidation";
+
+interface Agreements extends Record<string, boolean> {
+  all: boolean;
+  service: boolean;
+  privacy: boolean;
+  provision: boolean;
+  inquiry: boolean;
+  marketing: boolean;
+}
+
+export function useAgreementStep() {
+  const [agreements, setAgreements] = useState<Agreements>({
+    all: false,
+    service: false,
+    privacy: false,
+    provision: false,
+    inquiry: false,
+    marketing: false,
+  });
+
+  const handleAllAgreement = useCallback((checked: boolean) => {
+    setAgreements({
+      all: checked,
+      service: checked,
+      privacy: checked,
+      provision: checked,
+      inquiry: checked,
+      marketing: checked,
+    });
+  }, []);
+
+  const handleIndividualAgreement = useCallback(
+    (key: keyof Agreements, checked: boolean) => {
+      const newAgreements = { ...agreements, [key]: checked };
+
+      // 전체 동의 체크 여부 확인 (필수 약관들만 체크)
+      const allChecked = checkAllAgreements(newAgreements);
+
+      setAgreements({
+        ...newAgreements,
+        all: allChecked,
+      });
+    },
+    [agreements]
+  );
+
+  const validation = useMemo(() => {
+    return validateAgreements(agreements);
+  }, [agreements]);
+
+  const canProceed = useMemo(() => {
+    return validation.isValid;
+  }, [validation.isValid]);
+
+  const resetAgreements = useCallback(() => {
+    setAgreements({
+      all: false,
+      service: false,
+      privacy: false,
+      provision: false,
+      inquiry: false,
+      marketing: false,
+    });
+  }, []);
+
+  return {
+    agreements,
+    canProceed,
+    validation,
+    handleAllAgreement,
+    handleIndividualAgreement,
+    resetAgreements,
+  };
+}

--- a/src/hooks/sign-up/useBusinessStep.ts
+++ b/src/hooks/sign-up/useBusinessStep.ts
@@ -1,0 +1,101 @@
+import { useEffect } from "react";
+import { useFormContext } from "react-hook-form";
+import { useProgressCalculation } from "./useProgressCalculation";
+import { useBusinessVerification } from "./useBusinessVerification";
+import { useRegistration } from "./useRegistration";
+
+interface UseBusinessStepProps {
+  onComplete: (progress: number) => void;
+}
+
+export function useBusinessStep({ onComplete }: UseBusinessStepProps) {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    watch,
+  } = useFormContext();
+
+  const { calculateProgress } = useProgressCalculation();
+  const { isVerified, verifyToken, handleVerify } = useBusinessVerification();
+  const { handleRegistration } = useRegistration();
+
+  // 폼 데이터 감시
+  const businessNumber = watch("businessNumber");
+  const password = watch("password");
+  const passwordConfirm = watch("passwordConfirm");
+  const companyName = watch("companyName");
+  const representativeName = watch("representativeName");
+  const birthDate = watch("birthDate");
+  const phoneNumber = watch("phoneNumber");
+  const email = watch("email");
+
+  // 프로그레스 계산 및 업데이트
+  useEffect(() => {
+    const progress = calculateProgress({
+      businessNumber,
+      password,
+      passwordConfirm,
+      companyName,
+      representativeName,
+      birthDate,
+      phoneNumber,
+      email,
+    });
+    onComplete(progress);
+  }, [
+    businessNumber,
+    password,
+    passwordConfirm,
+    companyName,
+    representativeName,
+    birthDate,
+    phoneNumber,
+    email,
+    calculateProgress,
+    onComplete,
+  ]);
+
+  // 모든 필수 필드가 입력되었는지 확인
+  const canSubmit =
+    businessNumber &&
+    businessNumber.length === 10 &&
+    isVerified &&
+    password &&
+    passwordConfirm &&
+    password === passwordConfirm &&
+    representativeName &&
+    birthDate &&
+    birthDate.length === 8 &&
+    phoneNumber &&
+    email;
+
+  const onSubmit = async (data: any) => {
+    await handleRegistration({
+      businessNumber: data.businessNumber,
+      representativeName: data.representativeName,
+      password: data.password,
+      phoneNumber: data.phoneNumber,
+      email: data.email,
+      birthDate: data.birthDate,
+      verifyToken,
+    });
+  };
+
+  return {
+    register,
+    handleSubmit,
+    errors,
+    businessNumber,
+    password,
+    passwordConfirm,
+    representativeName,
+    birthDate,
+    phoneNumber,
+    email,
+    isVerified,
+    canSubmit,
+    onSubmit,
+    handleVerify,
+  };
+}

--- a/src/hooks/sign-up/useBusinessVerification.ts
+++ b/src/hooks/sign-up/useBusinessVerification.ts
@@ -1,0 +1,40 @@
+import { useState, useCallback } from "react";
+import { postVerifyBusinessNumber } from "@/apis/auth";
+
+export function useBusinessVerification() {
+  const [isVerified, setIsVerified] = useState(false);
+  const [verifyToken, setVerifyToken] = useState("");
+
+  const handleVerify = useCallback(async (businessNumber: string) => {
+    if (!businessNumber || businessNumber.length !== 10) {
+      return;
+    }
+
+    try {
+      const response = await postVerifyBusinessNumber({ businessNumber });
+      console.log("인증 응답:", response);
+
+      // 응답에서 토큰 추출
+      const responseData = await response.json();
+      console.log("인증 응답 데이터:", responseData);
+
+      const token = responseData.businessNumberVerifyToken;
+      setVerifyToken(token);
+      setIsVerified(true);
+    } catch (error) {
+      console.error("인증 실패:", error);
+    }
+  }, []);
+
+  const resetVerification = useCallback(() => {
+    setIsVerified(false);
+    setVerifyToken("");
+  }, []);
+
+  return {
+    isVerified,
+    verifyToken,
+    handleVerify,
+    resetVerification,
+  };
+}

--- a/src/hooks/sign-up/useCompanyInfoStep.ts
+++ b/src/hooks/sign-up/useCompanyInfoStep.ts
@@ -1,0 +1,43 @@
+import { useFormContext } from "react-hook-form";
+
+export function useCompanyInfoStep() {
+  const {
+    register,
+    formState: { errors },
+    setValue,
+    watch,
+  } = useFormContext();
+
+  const phoneNumber = watch("phoneNumber");
+
+  // 휴대폰번호 자동 하이픈 추가
+  const formatPhoneNumber = (value: string) => {
+    const numbers = value.replace(/[^0-9]/g, "");
+
+    if (numbers.length <= 3) {
+      return numbers;
+    } else if (numbers.length <= 7) {
+      return `${numbers.slice(0, 3)}-${numbers.slice(3)}`;
+    } else {
+      return `${numbers.slice(0, 3)}-${numbers.slice(3, 7)}-${numbers.slice(
+        7,
+        11
+      )}`;
+    }
+  };
+
+  const handlePhoneNumberChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    const formatted = formatPhoneNumber(value);
+    setValue("phoneNumber", formatted);
+  };
+
+  return {
+    register,
+    errors,
+    setValue,
+    watch,
+    phoneNumber,
+    handlePhoneNumberChange,
+  };
+}

--- a/src/hooks/sign-up/useProgressCalculation.ts
+++ b/src/hooks/sign-up/useProgressCalculation.ts
@@ -1,0 +1,59 @@
+import { useCallback } from "react";
+
+interface ProgressData {
+  businessNumber: string;
+  password: string;
+  passwordConfirm: string;
+  companyName: string;
+  representativeName: string;
+  birthDate: string;
+  phoneNumber: string;
+  email: string;
+}
+
+export function useProgressCalculation() {
+  const calculateProgress = useCallback((data: ProgressData) => {
+    let progress = 15; // 약관 동의 완료 시 15% 기본
+
+    // 사업자등록번호 (11%)
+    if (data.businessNumber && data.businessNumber.length === 10) {
+      progress += 11;
+    }
+
+    // 비밀번호 세트 (11%) - 두 개 다 채워야 함
+    if (
+      data.password &&
+      data.passwordConfirm &&
+      data.password === data.passwordConfirm
+    ) {
+      progress += 11;
+    }
+
+    // 상호명 (11%) - 고정값이므로 항상 추가
+    progress += 11;
+
+    // 대표자 (11%)
+    if (data.representativeName) {
+      progress += 11;
+    }
+
+    // 생년월일 (11%)
+    if (data.birthDate && data.birthDate.length === 8) {
+      progress += 11;
+    }
+
+    // 휴대폰 번호 (11%)
+    if (data.phoneNumber && /^01[0-9]-\d{3,4}-\d{4}$/.test(data.phoneNumber)) {
+      progress += 11;
+    }
+
+    // 이메일 (11%)
+    if (data.email) {
+      progress += 11;
+    }
+
+    return progress;
+  }, []);
+
+  return { calculateProgress };
+}

--- a/src/hooks/sign-up/useRegistration.ts
+++ b/src/hooks/sign-up/useRegistration.ts
@@ -1,0 +1,47 @@
+import { useCallback } from "react";
+import { postRegister } from "@/apis/auth";
+
+interface RegistrationData {
+  businessNumber: string;
+  representativeName: string;
+  password: string;
+  phoneNumber: string;
+  email: string;
+  birthDate: string;
+  verifyToken: string;
+}
+
+export function useRegistration() {
+  const handleRegistration = useCallback(async (data: RegistrationData) => {
+    try {
+      // 회원가입 API 호출
+      const registerData = {
+        businessNumber: data.businessNumber,
+        userName: data.representativeName, // 대표자명을 userName으로 사용
+        password: data.password,
+        companyName: "올라핀테크", // 고정값
+        phone: data.phoneNumber?.replace(/-/g, ""), // 하이픈 제거
+        email: data.email,
+        partnerId: "default", // 기본 파트너 ID 설정
+        birthDate: data.birthDate,
+        isMarketingConsent: true, // 기본값으로 true 설정
+        businessNumberVerifyToken: data.verifyToken, // 인증 후 받은 토큰 사용
+      };
+
+      console.log("회원가입 데이터:", registerData);
+
+      const response = await postRegister(registerData);
+      console.log("회원가입 성공:", response);
+
+      // 성공 시 처리 (예: 로그인 페이지로 리다이렉트)
+      alert("회원가입이 완료되었습니다!");
+      return { success: true, response };
+    } catch (error) {
+      console.error("회원가입 실패:", error);
+      alert("회원가입에 실패했습니다. 다시 시도해 주세요.");
+      return { success: false, error };
+    }
+  }, []);
+
+  return { handleRegistration };
+}

--- a/src/shared/button/Button.tsx
+++ b/src/shared/button/Button.tsx
@@ -16,14 +16,14 @@ const buttonVariants = cva(
         outline:
           "border border-input bg-background-default shadow-sm hover:bg-accent hover:text-accent-foreground",
         secondary:
-          "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
+          "bg-gray-300 text-gray-600 shadow-sm hover:bg-gray-400 disabled:bg-gray-200 disabled:text-gray-400",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
         default: "h-9 px-4 py-2",
         sm: "h-8 rounded-md px-3 text-xs",
-        lg: "h-10 rounded-md px-8",
+        lg: "h-12 rounded-md px-8",
         icon: "h-[20px] w-[20px]",
       },
     },


### PR DESCRIPTION
## 요약
약관 동의 → 사업자번호 인증 → 정보 입력의 3단계 플로우와 진행률 UI 구현.

## 변경사항
- `app/sign-up/page.tsx` 추가(멀티스텝/고정 프로그레스바)
- 컴포넌트 추가: `AgreementStep`, `BusinessStep`, `CompanyInfoStep`,
  `AgreementCheckbox/Header/List`, `BusinessNumberField`, `PasswordFields`, `CompanyInfoField`,
  상수 `agreementItems`, `companyInfoFields`
- 훅 추가: `useAgreementStep`, `useBusinessStep`, `useCompanyInfoStep`,
  `useBusinessVerification`, `useRegistration`, `useProgressCalculation`, `agreementValidation`
- 레이아웃: `/sign-up` 경로에서 푸터 미표시 (`Footer` 가드 + `components/layout/FooterWrapper`)
- 헤더: 버튼 링크 수정 — 회원가입(`/sign-up`), 로그인(`/login`)
- 의존성: `@radix-ui/react-checkbox`, `react-hook-form` 추가
- 기타: `CategoryTabs` 버튼 variant(ghost) 적용
