### PR TITLE
feat: login-page 구현 완료

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { LoginHeader, LoginPageContent } from "@/components/login";
+import { useLoginForm } from "@/hooks/login";
+
+export default function LoginPage() {
+  const {
+    saveId,
+    businessNumber,
+    password,
+    errors,
+    isLoading,
+    loginError,
+    setSaveId,
+    setBusinessNumber,
+    setPassword,
+    handleBusinessNumberBlur,
+    handlePasswordBlur,
+    handleSubmit,
+    handleSignUpClick,
+  } = useLoginForm();
+
+  return (
+    <article className="h-full">
+      <LoginHeader />
+      <LoginPageContent
+        businessNumber={businessNumber}
+        password={password}
+        saveId={saveId}
+        errors={errors}
+        isLoading={isLoading}
+        loginError={loginError}
+        onBusinessNumberChange={setBusinessNumber}
+        onPasswordChange={setPassword}
+        onSaveIdChange={setSaveId}
+        onBusinessNumberBlur={handleBusinessNumberBlur}
+        onPasswordBlur={handlePasswordBlur}
+        onSubmit={handleSubmit}
+        onSignUpClick={handleSignUpClick}
+      />
+    </article>
+  );
+}

--- a/src/app/sign-up/page.tsx
+++ b/src/app/sign-up/page.tsx
@@ -1,136 +1,36 @@
 "use client";
-import { useState, useEffect } from "react";
-import { useForm, FormProvider } from "react-hook-form";
-import {
-  AgreementStep,
-  BusinessStep,
-  CompanyInfoStep,
-} from "@/components/sign-up";
-
-interface SignUpFormData {
-  businessNumber: string;
-  password: string;
-  passwordConfirm: string;
-}
+import { FormProvider } from "react-hook-form";
+import { SignUpHeader } from "@/components/sign-up/SignUpHeader";
+import { ProgressBar } from "@/components/sign-up/ProgressBar";
+import { FixedProgressBar } from "@/components/sign-up/FixedProgressBar";
+import { StepContent } from "@/components/sign-up/StepContent";
+import { useSignUp } from "@/hooks/sign-up/useSignUp";
 
 export default function SignUpPage() {
-  const [progress, setProgress] = useState(0);
-  const [currentStep, setCurrentStep] = useState<
-    "agreement" | "business" | "companyInfo"
-  >("agreement");
-  const [showFixedProgress, setShowFixedProgress] = useState(false);
-
-  const methods = useForm<SignUpFormData>({
-    defaultValues: {
-      businessNumber: "",
-      password: "",
-      passwordConfirm: "",
-    },
-    mode: "onChange", // 입력하는 동안 실시간 유효성 검사
-  });
-
-  const handleProgressUpdate = (newProgress: number) => {
-    // 약관 동의 완료 시 15% 기본 설정
-    setProgress(15);
-    // 약관 동의 완료 후 다음 단계로 이동
-    setCurrentStep("business");
-  };
-
-  // 스크롤 감지하여 고정 프로그레스바 표시/숨김
-  useEffect(() => {
-    const handleScroll = () => {
-      const progressSection = document.getElementById("progress-section");
-
-      if (progressSection) {
-        const progressRect = progressSection.getBoundingClientRect();
-        // 프로그레스바가 화면에서 사라지면 고정 프로그레스바 표시
-        setShowFixedProgress(progressRect.bottom < 0);
-      }
-    };
-
-    window.addEventListener("scroll", handleScroll);
-    return () => window.removeEventListener("scroll", handleScroll);
-  }, []);
+  const {
+    progress,
+    currentStep,
+    showFixedProgress,
+    methods,
+    handleProgressUpdate,
+    updateProgress,
+  } = useSignUp();
 
   return (
     <FormProvider {...methods}>
-      <article className=" max-md:container pb-10 relative mx-auto max-w-[520px] md:px-7 space-y-8">
-        <header>
-          <h1 className="text-center text-title-2 md:text-title-1 lg:text-display-2">
-            지금 회원가입하면
-            <br />
-            <span className="font-bold">수수료 지원금 3만원 지급!</span>
-          </h1>
-        </header>
+      <article className="max-md:container pb-10 relative mx-auto max-w-[520px] md:px-7 space-y-8">
+        <SignUpHeader />
+
         <section id="progress-section">
-          <div className="relative space-y-0 sm:space-y-2">
-            <div className="flex items-center justify-between">
-              <div className="absolute bottom-0  z-0 h-[100px] w-[10px]"></div>
-              <span className="text-primary relative z-10 text-body-3 font-normal md:text-body-2">
-                최대 1,250만원까지 무료 선정산이 가능해요.
-              </span>
-              <span className="text-primary text-body-3 font-medium md:text-body-2 md:font-semibold">
-                {progress}%
-              </span>
-            </div>
-            <div
-              aria-valuemax={100}
-              aria-valuemin={0}
-              role="progressbar"
-              data-state="indeterminate"
-              data-max="100"
-              className="h-5 w-full overflow-hidden rounded-2xl bg-background-alternative relative space-y-0 sm:space-y-2"
-            >
-              <div
-                data-state="indeterminate"
-                data-max="100"
-                className="size-full flex-1 rounded-2xl bg-primary transition-all duration-500 relative space-y-0 sm:space-y-2"
-                style={{ transform: `translateX(-${100 - progress}%)` }}
-              ></div>
-            </div>
-            <div
-              className="fixed top-[60px] left-0 z-50 h-4 w-[100dvw] overflow-hidden bg-label-200 transition-opacity duration-300"
-              style={{ opacity: showFixedProgress ? 1 : 0 }}
-            >
-              <div
-                className="absolute top-0 left-0 h-full bg-primary transition-all duration-300"
-                style={{ width: `${progress}%` }}
-              ></div>
-              <div className="fixed top-[80px] left-1/2 z-50 h-5 w-[80%] max-w-[520px] -translate-x-1/2">
-                <div className="flex justify-between rounded-lg bg-background-default px-7 py-6 text-primary shadow-strong">
-                  <span className="text-body-3 font-normal md:text-body-2">
-                    최대 1,250만원까지 무료 선정산이 가능해요.
-                  </span>
-                  <span className="text-body-3 font-medium md:text-body-2 md:font-semibold">
-                    {progress}%
-                  </span>
-                </div>
-              </div>
-            </div>
-          </div>
+          <ProgressBar progress={progress} />
         </section>
 
-        {currentStep === "agreement" && (
-          <section>
-            <AgreementStep onComplete={handleProgressUpdate} />
-          </section>
-        )}
+        <FixedProgressBar progress={progress} isVisible={showFixedProgress} />
 
-        {currentStep === "business" && (
-          <section>
-            <BusinessStep
-              onComplete={(progress) => {
-                setProgress(progress);
-              }}
-            />
-          </section>
-        )}
-
-        {currentStep === "companyInfo" && (
-          <section>
-            <CompanyInfoStep />
-          </section>
-        )}
+        <StepContent
+          currentStep={currentStep}
+          onProgressUpdate={handleProgressUpdate}
+        />
       </article>
     </FormProvider>
   );

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -9,8 +9,8 @@ import FooterCustomerService from "./FooterCustomerService";
 const Footer = () => {
   const pathname = usePathname();
 
-  // 회원가입 페이지에서는 푸터 숨김
-  if (pathname.startsWith("/sign-up")) {
+  // 회원가입 페이지와 로그인 페이지에서는 푸터 숨김
+  if (pathname.startsWith("/sign-up") || pathname.startsWith("/login")) {
     return null;
   }
 

--- a/src/components/header/HeaderMobileActions.tsx
+++ b/src/components/header/HeaderMobileActions.tsx
@@ -6,7 +6,7 @@ const HeaderMobileActions = () => {
   return (
     <div className="flex items-center gap-4 lg:hidden">
       <Link
-        href="/sign-up"
+        href="/login"
         className="inline-flex items-center justify-center whitespace-nowrap cursor-pointer disabled:cursor-not-allowed border border-secondary-300 bg-background-default text-primary hover:border-secondary-300 hover:bg-label-100 active:bg-background-alternative disabled:border-status-disable disabled:bg-background-default disabled:text-status-disable h-[32px] gap-1 rounded-sm px-6 text-body-3 font-medium"
       >
         로그인/회원가입

--- a/src/components/login/LoginForm.tsx
+++ b/src/components/login/LoginForm.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { Check } from "lucide-react";
+import { Input } from "@/shared/input/Input";
+import * as Checkbox from "@radix-ui/react-checkbox";
+import { Button } from "@/shared/button/Button";
+
+interface LoginFormProps {
+  businessNumber: string;
+  password: string;
+  saveId: boolean;
+  errors: Record<string, string>;
+  isLoading: boolean;
+  loginError: string;
+  onBusinessNumberChange: (value: string) => void;
+  onPasswordChange: (value: string) => void;
+  onSaveIdChange: (checked: boolean) => void;
+  onBusinessNumberBlur: () => void;
+  onPasswordBlur: () => void;
+  onSubmit: (e: React.FormEvent) => void;
+  onSignUpClick: () => void;
+}
+
+export function LoginForm({
+  businessNumber,
+  password,
+  saveId,
+  errors,
+  isLoading,
+  loginError,
+  onBusinessNumberChange,
+  onPasswordChange,
+  onSaveIdChange,
+  onBusinessNumberBlur,
+  onPasswordBlur,
+  onSubmit,
+  onSignUpClick,
+}: LoginFormProps) {
+  return (
+    <form onSubmit={onSubmit}>
+      <div className="flex flex-col gap-6">
+        {/* 로그인 에러 메시지 */}
+        {loginError && (
+          <div className="p-4 bg-red-50 border border-red-200 rounded-lg">
+            <p className="text-red-600 text-body-3">{loginError}</p>
+          </div>
+        )}
+
+        <div className="space-y-3">
+          <label
+            className="peer-disabled:cursor-not-allowed peer-disabled:text-status-disable text-body-3 font-medium text-label-700"
+            htmlFor="_r_14_-form-item"
+          >
+            사업자등록번호(ID로 사용돼요)
+          </label>
+          <Input
+            className={`h-[48px] rounded-lg px-6 text-body-2 placeholder:text-body-2 border-2 transition-colors ${
+              errors.businessNumber
+                ? "border-red-500 focus:border-red-500"
+                : "border-gray-300 focus:border-primary"
+            }`}
+            placeholder="사업자등록번호를 입력해 주세요"
+            id="_r_14_-form-item"
+            type="text"
+            value={businessNumber}
+            onChange={(e) => onBusinessNumberChange(e.target.value)}
+            onBlur={onBusinessNumberBlur}
+            disabled={isLoading}
+          />
+          {errors.businessNumber && (
+            <p
+              id="_r_14_-form-item-message"
+              className="text-caption-1 font-medium text-status-error"
+            >
+              {errors.businessNumber}
+            </p>
+          )}
+        </div>
+        <div>
+          <div className="space-y-3">
+            <label
+              className="peer-disabled:cursor-not-allowed peer-disabled:text-status-disable text-body-3 font-medium text-label-700"
+              htmlFor="_r_15_-form-item"
+            >
+              비밀번호
+            </label>
+            <div className="relative w-full">
+              <Input
+                className={`h-[48px] rounded-lg px-6 text-body-2 placeholder:text-body-2 border-2 transition-colors ${
+                  errors.password
+                    ? "border-red-500 focus:border-red-500"
+                    : "border-gray-300 focus:border-primary"
+                }`}
+                placeholder="비밀번호를 입력해 주세요"
+                id="_r_15_-form-item"
+                type="password"
+                value={password}
+                onChange={(e) => onPasswordChange(e.target.value)}
+                onBlur={onPasswordBlur}
+                disabled={isLoading}
+              />
+            </div>
+            {errors.password && (
+              <p
+                id="_r_15_-form-item-message"
+                className="text-caption-1 font-medium text-status-error"
+              >
+                {errors.password}
+              </p>
+            )}
+          </div>
+        </div>
+        <div className="flex items-center gap-1"></div>
+        <section>
+          <div className="flex items-center justify-between">
+            <label className="text-body-2 font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:text-status-disable text-label-900 flex cursor-pointer items-center gap-3 space-y-0">
+              <Checkbox.Root
+                id="save-id"
+                checked={saveId}
+                onCheckedChange={(checked) =>
+                  onSaveIdChange(checked as boolean)
+                }
+                className="w-[20px] h-[20px] rounded border-2 border-gray-300 flex items-center justify-center hover:border-primary transition-colors data-[state=checked]:bg-primary data-[state=checked]:border-primary"
+                disabled={isLoading}
+              >
+                <Checkbox.Indicator>
+                  <Check className="w-4 h-4 text-white" />
+                </Checkbox.Indicator>
+              </Checkbox.Root>
+              <span className="text-body-3 font-medium text-label-700">
+                아이디 저장
+              </span>
+            </label>
+          </div>
+          <div className="mt-9 flex w-full flex-col gap-4 lg:mt-10">
+            <Button
+              type="submit"
+              className="h-[48px] md:h-[56px] !text-title-4 text-white"
+              disabled={isLoading}
+            >
+              {isLoading ? "로그인 중..." : "로그인"}
+            </Button>
+            <Button
+              type="button"
+              className="h-[48px] md:h-[56px] border-primary !text-title-4 text-primary rounded-lg"
+              variant="outline"
+              disabled={isLoading}
+              onClick={onSignUpClick}
+            >
+              회원가입
+            </Button>
+          </div>
+        </section>
+      </div>
+    </form>
+  );
+}

--- a/src/components/login/LoginHeader.tsx
+++ b/src/components/login/LoginHeader.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import Link from "next/link";
+import { ChevronRight } from "lucide-react";
+
+export function LoginHeader() {
+  return (
+    <nav className="w-full fixed top-header left-0 z-30 bg-label-100">
+      <div className="container flex items-center justify-end bg-label-100 font-normal text-label-700 h-breadcrumb-mobile text-caption-1 md:h-breadcrumb-tablet md:text-body-3">
+        <ol className="flex items-center gap-1 text-body-3">
+          <li>
+            <Link href="/">홈</Link>
+          </li>
+          <ChevronRight className="w-[16px] h-[16px]" />
+          <li>
+            <Link href="/login">로그인</Link>
+          </li>
+        </ol>
+      </div>
+    </nav>
+  );
+}

--- a/src/components/login/LoginPageContent.tsx
+++ b/src/components/login/LoginPageContent.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { LoginForm } from "./LoginForm";
+
+interface LoginPageContentProps {
+  businessNumber: string;
+  password: string;
+  saveId: boolean;
+  errors: Record<string, string>;
+  isLoading: boolean;
+  loginError: string;
+  onBusinessNumberChange: (value: string) => void;
+  onPasswordChange: (value: string) => void;
+  onSaveIdChange: (checked: boolean) => void;
+  onBusinessNumberBlur: () => void;
+  onPasswordBlur: () => void;
+  onSubmit: (e: React.FormEvent) => void;
+  onSignUpClick: () => void;
+}
+
+export function LoginPageContent({
+  businessNumber,
+  password,
+  saveId,
+  errors,
+  isLoading,
+  loginError,
+  onBusinessNumberChange,
+  onPasswordChange,
+  onSaveIdChange,
+  onBusinessNumberBlur,
+  onPasswordBlur,
+  onSubmit,
+  onSignUpClick,
+}: LoginPageContentProps) {
+  return (
+    <div className="mx-auto  max-w-[480px] h-full max-md:container">
+      <div className="pt-[80px] max-md:container pb-10 relative mx-auto max-w-[520px] md:px-7 space-y-8">
+        <header>
+          <h3 className="text-title-3 font-medium md:text-title-2">로그인</h3>
+        </header>
+        <LoginForm
+          businessNumber={businessNumber}
+          password={password}
+          saveId={saveId}
+          errors={errors}
+          isLoading={isLoading}
+          loginError={loginError}
+          onBusinessNumberChange={onBusinessNumberChange}
+          onPasswordChange={onPasswordChange}
+          onSaveIdChange={onSaveIdChange}
+          onBusinessNumberBlur={onBusinessNumberBlur}
+          onPasswordBlur={onPasswordBlur}
+          onSubmit={onSubmit}
+          onSignUpClick={onSignUpClick}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/login/index.ts
+++ b/src/components/login/index.ts
@@ -1,0 +1,3 @@
+export { LoginHeader } from "./LoginHeader";
+export { LoginForm } from "./LoginForm";
+export { LoginPageContent } from "./LoginPageContent";

--- a/src/components/sign-up/FixedProgressBar.tsx
+++ b/src/components/sign-up/FixedProgressBar.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+interface FixedProgressBarProps {
+  progress: number;
+  isVisible: boolean;
+}
+
+export function FixedProgressBar({
+  progress,
+  isVisible,
+}: FixedProgressBarProps) {
+  return (
+    <div
+      className="fixed top-[60px] left-0 z-50 h-4 w-[100dvw] overflow-hidden bg-label-200 transition-opacity duration-300"
+      style={{ opacity: isVisible ? 1 : 0 }}
+    >
+      <div
+        className="absolute top-0 left-0 h-full bg-primary transition-all duration-300"
+        style={{ width: `${progress}%` }}
+      ></div>
+      <div className="fixed top-[80px] left-1/2 z-50 h-5 w-[80%] max-w-[520px] -translate-x-1/2">
+        <div className="flex justify-between rounded-lg bg-background-default px-7 py-6 text-primary shadow-strong">
+          <span className="text-body-3 font-normal md:text-body-2">
+            최대 1,250만원까지 무료 선정산이 가능해요.
+          </span>
+          <span className="text-body-3 font-medium md:text-body-2 md:font-semibold">
+            {progress}%
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/sign-up/ProgressBar.tsx
+++ b/src/components/sign-up/ProgressBar.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+interface ProgressBarProps {
+  progress: number;
+}
+
+export function ProgressBar({ progress }: ProgressBarProps) {
+  return (
+    <div className="relative space-y-0 sm:space-y-2">
+      <div className="flex items-center justify-between">
+        <div className="absolute bottom-0 z-0 h-[100px] w-[10px]"></div>
+        <span className="text-primary relative z-10 text-body-3 font-normal md:text-body-2">
+          최대 1,250만원까지 무료 선정산이 가능해요.
+        </span>
+        <span className="text-primary text-body-3 font-medium md:text-body-2 md:font-semibold">
+          {progress}%
+        </span>
+      </div>
+      <div
+        aria-valuemax={100}
+        aria-valuemin={0}
+        role="progressbar"
+        data-state="indeterminate"
+        data-max="100"
+        className="h-5 w-full overflow-hidden rounded-2xl bg-background-alternative relative space-y-0 sm:space-y-2"
+      >
+        <div
+          data-state="indeterminate"
+          data-max="100"
+          className="size-full flex-1 rounded-2xl bg-primary transition-all duration-500 relative space-y-0 sm:space-y-2"
+          style={{ transform: `translateX(-${100 - progress}%)` }}
+        ></div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/sign-up/SignUpHeader.tsx
+++ b/src/components/sign-up/SignUpHeader.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+export function SignUpHeader() {
+  return (
+    <header>
+      <h1 className="text-center text-title-2 md:text-title-1 lg:text-display-2">
+        지금 회원가입하면
+        <br />
+        <span className="font-bold">수수료 지원금 3만원 지급!</span>
+      </h1>
+    </header>
+  );
+}

--- a/src/components/sign-up/StepContent.tsx
+++ b/src/components/sign-up/StepContent.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { AgreementStep, BusinessStep, CompanyInfoStep } from "./index";
+
+interface StepContentProps {
+  currentStep: "agreement" | "business" | "companyInfo";
+  onProgressUpdate: (progress: number) => void;
+}
+
+export function StepContent({
+  currentStep,
+  onProgressUpdate,
+}: StepContentProps) {
+  const handleAgreementComplete = (progress: number) => {
+    onProgressUpdate(progress);
+  };
+
+  const handleBusinessComplete = (progress: number) => {
+    onProgressUpdate(progress);
+  };
+
+  return (
+    <>
+      {currentStep === "agreement" && (
+        <section>
+          <AgreementStep onComplete={handleAgreementComplete} />
+        </section>
+      )}
+
+      {currentStep === "business" && (
+        <section>
+          <BusinessStep onComplete={handleBusinessComplete} />
+        </section>
+      )}
+
+      {currentStep === "companyInfo" && (
+        <section>
+          <CompanyInfoStep />
+        </section>
+      )}
+    </>
+  );
+}

--- a/src/components/sign-up/index.ts
+++ b/src/components/sign-up/index.ts
@@ -7,3 +7,7 @@ export { BusinessNumberField } from "./BusinessNumberField";
 export { PasswordFields } from "./PasswordFields";
 export { CompanyInfoStep } from "./CompanyInfoStep";
 export { CompanyInfoField } from "./CompanyInfoField";
+export { SignUpHeader } from "./SignUpHeader";
+export { ProgressBar } from "./ProgressBar";
+export { FixedProgressBar } from "./FixedProgressBar";
+export { StepContent } from "./StepContent";

--- a/src/hooks/login/index.ts
+++ b/src/hooks/login/index.ts
@@ -1,0 +1,1 @@
+export { useLoginForm } from "./useLoginForm";

--- a/src/hooks/login/useLoginForm.ts
+++ b/src/hooks/login/useLoginForm.ts
@@ -1,0 +1,132 @@
+import { useState, useEffect } from "react";
+import { postLogin, saveTokens } from "@/apis/auth";
+import { useRouter } from "next/navigation";
+
+export function useLoginForm() {
+  const router = useRouter();
+  const [saveId, setSaveId] = useState(false);
+  const [businessNumber, setBusinessNumber] = useState("");
+  const [password, setPassword] = useState("");
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [isLoading, setIsLoading] = useState(false);
+  const [loginError, setLoginError] = useState("");
+
+  const handleBusinessNumberBlur = () => {
+    if (businessNumber.trim() && businessNumber.length !== 10) {
+      setErrors((prev) => ({
+        ...prev,
+        businessNumber: "사업자등록번호 10자리를 입력해 주세요.",
+      }));
+    } else {
+      setErrors((prev) => ({ ...prev, businessNumber: "" }));
+    }
+  };
+
+  const handlePasswordBlur = () => {
+    if (password.trim() && (password.length < 8 || password.length > 15)) {
+      setErrors((prev) => ({
+        ...prev,
+        password: "8~15자리 영문, 숫자, 특수문자로 조합하여 입력해주세요",
+      }));
+    } else {
+      setErrors((prev) => ({ ...prev, password: "" }));
+    }
+  };
+
+  const validateForm = () => {
+    const newErrors: Record<string, string> = {};
+
+    if (!businessNumber.trim()) {
+      newErrors.businessNumber = "사업자등록번호를 입력해주세요";
+    } else if (businessNumber.length !== 10) {
+      newErrors.businessNumber = "사업자등록번호 10자리를 입력해 주세요.";
+    }
+
+    if (!password.trim()) {
+      newErrors.password = "비밀번호를 입력해주세요";
+    } else if (password.length < 8 || password.length > 15) {
+      newErrors.password =
+        "8~15자리 영문, 숫자, 특수문자로 조합하여 입력해주세요";
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoginError("");
+
+    if (!validateForm()) {
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      const response = await postLogin({
+        businessNumber: businessNumber.trim(),
+        password: password.trim(),
+      });
+
+      const data = await response.json();
+
+      if (response.ok) {
+        // 토큰 저장
+        saveTokens(data);
+
+        // 아이디 저장 처리
+        if (saveId) {
+          localStorage.setItem("savedBusinessNumber", businessNumber);
+        } else {
+          localStorage.removeItem("savedBusinessNumber");
+        }
+
+        // 홈페이지로 이동
+        router.push("/");
+      } else {
+        // API 에러 처리
+        setLoginError(
+          data.errorMessage || "로그인에 실패했습니다. 다시 시도해주세요."
+        );
+      }
+    } catch (error) {
+      console.error("로그인 에러:", error);
+      setLoginError("로그인 중 오류가 발생했습니다. 다시 시도해주세요.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleSignUpClick = () => {
+    router.push("/sign-up");
+  };
+
+  // 저장된 아이디 불러오기
+  useEffect(() => {
+    const savedBusinessNumber = localStorage.getItem("savedBusinessNumber");
+    if (savedBusinessNumber) {
+      setBusinessNumber(savedBusinessNumber);
+      setSaveId(true);
+    }
+  }, []);
+
+  return {
+    // 상태
+    saveId,
+    businessNumber,
+    password,
+    errors,
+    isLoading,
+    loginError,
+
+    // 이벤트 핸들러
+    setSaveId,
+    setBusinessNumber,
+    setPassword,
+    handleBusinessNumberBlur,
+    handlePasswordBlur,
+    handleSubmit,
+    handleSignUpClick,
+  };
+}

--- a/src/hooks/sign-up/index.ts
+++ b/src/hooks/sign-up/index.ts
@@ -4,6 +4,10 @@ export { useBusinessStep } from "./useBusinessStep";
 export { useProgressCalculation } from "./useProgressCalculation";
 export { useBusinessVerification } from "./useBusinessVerification";
 export { useRegistration } from "./useRegistration";
+export { useSignUp } from "./useSignUp";
+export { useSignUpProgress } from "./useSignUpProgress";
+export { useScrollProgress } from "./useScrollProgress";
+export { useSignUpForm } from "./useSignUpForm";
 export {
   validateAgreements,
   checkAllAgreements,

--- a/src/hooks/sign-up/useRegistration.ts
+++ b/src/hooks/sign-up/useRegistration.ts
@@ -1,4 +1,5 @@
 import { useCallback } from "react";
+import { useRouter } from "next/navigation";
 import { postRegister } from "@/apis/auth";
 
 interface RegistrationData {
@@ -12,36 +13,43 @@ interface RegistrationData {
 }
 
 export function useRegistration() {
-  const handleRegistration = useCallback(async (data: RegistrationData) => {
-    try {
-      // 회원가입 API 호출
-      const registerData = {
-        businessNumber: data.businessNumber,
-        userName: data.representativeName, // 대표자명을 userName으로 사용
-        password: data.password,
-        companyName: "올라핀테크", // 고정값
-        phone: data.phoneNumber?.replace(/-/g, ""), // 하이픈 제거
-        email: data.email,
-        partnerId: "default", // 기본 파트너 ID 설정
-        birthDate: data.birthDate,
-        isMarketingConsent: true, // 기본값으로 true 설정
-        businessNumberVerifyToken: data.verifyToken, // 인증 후 받은 토큰 사용
-      };
+  const router = useRouter();
 
-      console.log("회원가입 데이터:", registerData);
+  const handleRegistration = useCallback(
+    async (data: RegistrationData) => {
+      try {
+        // 회원가입 API 호출
+        const registerData = {
+          businessNumber: data.businessNumber,
+          userName: data.representativeName, // 대표자명을 userName으로 사용
+          password: data.password,
+          companyName: "올라핀테크", // 고정값
+          phone: data.phoneNumber?.replace(/-/g, ""), // 하이픈 제거
+          email: data.email,
+          partnerId: "default", // 기본 파트너 ID 설정
+          birthDate: data.birthDate,
+          isMarketingConsent: true, // 기본값으로 true 설정
+          businessNumberVerifyToken: data.verifyToken, // 인증 후 받은 토큰 사용
+        };
 
-      const response = await postRegister(registerData);
-      console.log("회원가입 성공:", response);
+        console.log("회원가입 데이터:", registerData);
 
-      // 성공 시 처리 (예: 로그인 페이지로 리다이렉트)
-      alert("회원가입이 완료되었습니다!");
-      return { success: true, response };
-    } catch (error) {
-      console.error("회원가입 실패:", error);
-      alert("회원가입에 실패했습니다. 다시 시도해 주세요.");
-      return { success: false, error };
-    }
-  }, []);
+        const response = await postRegister(registerData);
+        console.log("회원가입 성공:", response);
+
+        // 성공 시 로그인 페이지로 리다이렉트
+        alert("회원가입이 완료되었습니다!");
+        router.push("/login");
+
+        return { success: true, response };
+      } catch (error) {
+        console.error("회원가입 실패:", error);
+        alert("회원가입에 실패했습니다. 다시 시도해 주세요.");
+        return { success: false, error };
+      }
+    },
+    [router]
+  );
 
   return { handleRegistration };
 }

--- a/src/hooks/sign-up/useScrollProgress.ts
+++ b/src/hooks/sign-up/useScrollProgress.ts
@@ -1,0 +1,24 @@
+import { useState, useEffect, useCallback } from "react";
+
+export function useScrollProgress() {
+  const [showFixedProgress, setShowFixedProgress] = useState(false);
+
+  const handleScroll = useCallback(() => {
+    const progressSection = document.getElementById("progress-section");
+
+    if (progressSection) {
+      const progressRect = progressSection.getBoundingClientRect();
+      // 프로그레스바가 화면에서 사라지면 고정 프로그레스바 표시
+      setShowFixedProgress(progressRect.bottom < 0);
+    }
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, [handleScroll]);
+
+  return {
+    showFixedProgress,
+  };
+}

--- a/src/hooks/sign-up/useSignUp.ts
+++ b/src/hooks/sign-up/useSignUp.ts
@@ -1,0 +1,19 @@
+import { useSignUpProgress } from "./useSignUpProgress";
+import { useScrollProgress } from "./useScrollProgress";
+import { useSignUpForm } from "./useSignUpForm";
+
+export function useSignUp() {
+  const { progress, currentStep, handleProgressUpdate, updateProgress } =
+    useSignUpProgress();
+  const { showFixedProgress } = useScrollProgress();
+  const { methods } = useSignUpForm();
+
+  return {
+    progress,
+    currentStep,
+    showFixedProgress,
+    methods,
+    handleProgressUpdate,
+    updateProgress,
+  };
+}

--- a/src/hooks/sign-up/useSignUpForm.ts
+++ b/src/hooks/sign-up/useSignUpForm.ts
@@ -1,0 +1,22 @@
+import { useForm } from "react-hook-form";
+
+interface SignUpFormData {
+  businessNumber: string;
+  password: string;
+  passwordConfirm: string;
+}
+
+export function useSignUpForm() {
+  const methods = useForm<SignUpFormData>({
+    defaultValues: {
+      businessNumber: "",
+      password: "",
+      passwordConfirm: "",
+    },
+    mode: "onChange", // 입력하는 동안 실시간 유효성 검사
+  });
+
+  return {
+    methods,
+  };
+}

--- a/src/hooks/sign-up/useSignUpProgress.ts
+++ b/src/hooks/sign-up/useSignUpProgress.ts
@@ -1,0 +1,31 @@
+import { useState, useCallback } from "react";
+
+type SignUpStep = "agreement" | "business" | "companyInfo";
+
+export function useSignUpProgress() {
+  const [progress, setProgress] = useState(0);
+  const [currentStep, setCurrentStep] = useState<SignUpStep>("agreement");
+
+  const handleProgressUpdate = useCallback((newProgress: number) => {
+    // 약관 동의 완료 시 15% 기본 설정
+    setProgress(15);
+    // 약관 동의 완료 후 다음 단계로 이동
+    setCurrentStep("business");
+  }, []);
+
+  const updateProgress = useCallback((newProgress: number) => {
+    setProgress(newProgress);
+  }, []);
+
+  const goToStep = useCallback((step: SignUpStep) => {
+    setCurrentStep(step);
+  }, []);
+
+  return {
+    progress,
+    currentStep,
+    handleProgressUpdate,
+    updateProgress,
+    goToStep,
+  };
+}

--- a/src/shared/button/Button.tsx
+++ b/src/shared/button/Button.tsx
@@ -45,7 +45,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     const Comp = asChild ? Slot : "button";
     return (
       <Comp
-        className={cn(buttonVariants({ variant, size, className }))}
+        className={cn(buttonVariants({ variant, size }), className)}
         ref={ref}
         {...props}
       />


### PR DESCRIPTION
## 요약
로그인 페이지 완성(검증/아이디 저장/토큰 저장). 회원가입 페이지는 진행률·스크롤 고정바·스텝 영역을 컴포넌트/훅으로 분리해 가독성과 재사용성 개선. 로그인/회원가입 UX 맞춰 헤더/푸터 노출 조건 정리.

## 변경사항
- 페이지
  - `app/login/page.tsx` 추가: `useLoginForm`로 상태/검증/제출 처리, `LoginHeader`+`LoginPageContent` 구성
  - `app/sign-up/page.tsx` 리팩토링: 내부 상태/마크업 제거 → `SignUpHeader`/`ProgressBar`/`FixedProgressBar`/`StepContent` + `useSignUp`로 대체
- 컴포넌트 (login)
  - `components/login/LoginHeader.tsx` 추가: 상단 브레드크럼
  - `components/login/LoginForm.tsx` 추가: 사업자번호/비밀번호, 아이디 저장 체크박스, 에러/로딩 UI
  - `components/login/LoginPageContent.tsx` 추가 및 `components/login/index.ts` export
- 컴포넌트 (sign-up)
  - `components/sign-up/SignUpHeader.tsx`, `ProgressBar.tsx`, `FixedProgressBar.tsx`, `StepContent.tsx` 추가
  - `components/sign-up/index.ts` export 갱신
- 훅 (login)
  - `hooks/login/useLoginForm.ts` 추가 및 `hooks/login/index.ts` export  
    - blur 검증, 제출 시 `postLogin` 호출, `saveTokens` 저장, 아이디 저장(LocalStorage), 성공 시 `/` 이동
- 훅 (sign-up)
  - `useSignUp.ts`, `useSignUpProgress.ts`, `useScrollProgress.ts`, `useSignUpForm.ts` 추가
  - `useRegistration` 성공 시 `/login` 리다이렉트하도록 변경
  - `hooks/sign-up/index.ts` export 갱신
- 레이아웃/네비게이션
  - `components/footer/Footer.tsx`: `/sign-up` **및** `/login`에서 푸터 숨김
  - `components/header/HeaderMobileActions.tsx`: 버튼 링크 `/login`으로 변경
- 공통
  - `shared/button/Button.tsx`: `className` merge 순서 정리(가변 클래스 우선)

